### PR TITLE
Add SMTLIB program samples compatible with z3 for finding test packets

### DIFF
--- a/samples/Makefile
+++ b/samples/Makefile
@@ -16,7 +16,7 @@ COMPILED_FILE_NAMES := $(SOURCE_FILE_NAMES:.p4=.json)
 build: $(COMPILED_FILE_NAMES)
 
 %.json: %.p4
-	p4c --std p4_16 --target bmv2 --arch v1model $<
+	p4c --std p4_16 --target bmv2 --arch v1model --p4runtime-files $(basename $@).info.json $<
 
 #
 # bmv2 simulation
@@ -61,7 +61,7 @@ kill:
 	@sudo kill `cat $(TCPDUMP_PID)` && rm $(TCPDUMP_PID)
 
 clean:
-	@rm -f *.json *.p4i *.log
+	@rm -f *.json *.p4i *.log *.info.*
 
 # PHONY rules with names that do not correspond to files
 .PHONY: build simple_switch veth control_plane packets stop kill clean

--- a/z3-samples/paths/paths.opt1.smt2
+++ b/z3-samples/paths/paths.opt1.smt2
@@ -1,0 +1,161 @@
+;; Packet attributes
+(declare-const ingress_port Int)
+(declare-const dstAddr (_ BitVec 32))
+
+;; Table output parameters
+(declare-const vrf Int)
+
+;; Table Matches
+;; port_to_vrf
+(define-fun port_to_vrf0 () Bool (= ingress_port 0))
+(define-fun port_to_vrf1 () Bool (= ingress_port 1))
+
+;; vrf_ip_to_port
+;;
+;; There are several ways to handle lpm overlaps, priorities, etc
+;; one simple way is to define each key match as its own alias indpendently
+;; then combine them when defining a row match with the appropriate negations.
+;;
+;; It would have been nice to always mindlessly negate all other lpm matches when defining
+;; one match. However, this won't work:
+;; (1) there are other field matches  (e.g. vrf) and if they are different, there is no overlap.
+;; (2) lpm overlaps are directional, they must be included in the largest prefix, but not the others.
+;;
+(define-fun vrf_ip_to_port0_lpm () Bool (= ((_ extract 31 8) dstAddr) #x0a0a00)) ;; 10.10.0.*
+(define-fun vrf_ip_to_port1_lpm () Bool (= ((_ extract 31 16) dstAddr) #x0a0a)) ;; 10.10.*.*
+(define-fun vrf_ip_to_port2_lpm () Bool (= ((_ extract 31 16) dstAddr) #x1414)) ;; 20.20.*.*
+
+(define-fun vrf_ip_to_port0 () Bool (and
+    vrf_ip_to_port0_lpm
+    (= vrf 10)
+))
+(define-fun vrf_ip_to_port1 () Bool (and
+    ;; our code determines which combinations are needed
+    ;; can invoke the SMT solver to find when!
+    (and (not vrf_ip_to_port0_lpm) vrf_ip_to_port1_lpm)
+    (= vrf 10)
+))
+(define-fun vrf_ip_to_port2 () Bool (and
+    vrf_ip_to_port2_lpm
+    (= vrf 20)
+))
+
+;; Branches
+(define-fun set_port_if1_then () Bool (= dstAddr #x0a0a0000))
+(define-fun set_port_if1_else () Bool (not (= dstAddr #x0a0a0000)))
+
+;; link vrf value to table match
+;;
+;; simple way of doing it
+;; encode the table mechanism in SMT
+;; if statements proportional to table size
+;; not very efficient probably
+;;
+(assert (= vrf
+    (ite port_to_vrf0 10
+        (ite port_to_vrf1 20
+            -1
+        )
+    )
+))
+
+;; Combinations
+;;
+;; Mindlessly dump all combintations, even ones that are obviously impossible.
+;;
+(push)
+(echo "combination 1")
+(assert (and port_to_vrf0 vrf_ip_to_port0 set_port_if1_then))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 2")
+(assert (and port_to_vrf0 vrf_ip_to_port0 set_port_if1_else))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 3")
+(assert (and port_to_vrf0 vrf_ip_to_port1 set_port_if1_then))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 4")
+(assert (and port_to_vrf0 vrf_ip_to_port1 set_port_if1_else))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 5")
+(assert (and port_to_vrf0 vrf_ip_to_port2 set_port_if1_then))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 6")
+(assert (and port_to_vrf0 vrf_ip_to_port2 set_port_if1_else))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 7")
+(assert (and port_to_vrf1 vrf_ip_to_port0 set_port_if1_then))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 8")
+(assert (and port_to_vrf1 vrf_ip_to_port0 set_port_if1_else))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 9")
+(assert (and port_to_vrf1 vrf_ip_to_port1 set_port_if1_then))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 10")
+(assert (and port_to_vrf1 vrf_ip_to_port1 set_port_if1_else))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 11")
+(assert (and port_to_vrf1 vrf_ip_to_port2 set_port_if1_then))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 12")
+(assert (and port_to_vrf1 vrf_ip_to_port2 set_port_if1_else))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+

--- a/z3-samples/paths/paths.opt2.smt2
+++ b/z3-samples/paths/paths.opt2.smt2
@@ -1,0 +1,100 @@
+;; Packet attributes
+(declare-const ingress_port Int)
+(declare-const dstAddr (_ BitVec 32))
+
+;; Table output parameters
+(declare-const vrf Int)
+
+;; Table Matches
+;; port_to_vrf
+(define-fun port_to_vrf0 () Bool (= ingress_port 0))
+(define-fun port_to_vrf1 () Bool (= ingress_port 1))
+
+;; vrf_ip_to_port
+(define-fun vrf_ip_to_port0_lpm () Bool (= ((_ extract 31 8) dstAddr) #x0a0a00)) ;; 10.10.0.*
+(define-fun vrf_ip_to_port1_lpm () Bool (= ((_ extract 31 16) dstAddr) #x0a0a)) ;; 10.10.*.*
+(define-fun vrf_ip_to_port2_lpm () Bool (= ((_ extract 31 16) dstAddr) #x1414)) ;; 20.20.*.*
+
+(define-fun vrf_ip_to_port0 () Bool (and
+    vrf_ip_to_port0_lpm
+    (= vrf 10)
+))
+(define-fun vrf_ip_to_port1 () Bool (and
+    (and (not vrf_ip_to_port0_lpm) vrf_ip_to_port1_lpm)
+    (= vrf 10)
+))
+(define-fun vrf_ip_to_port2 () Bool (and
+    vrf_ip_to_port2_lpm
+    (= vrf 20)
+))
+
+;; Branches
+(define-fun set_port_if1_then () Bool (= dstAddr #x0a0a0000))
+(define-fun set_port_if1_else () Bool (not (= dstAddr #x0a0a0000)))
+
+;; link vrf value to table match
+;;
+;; Better way:
+;; define all the different values for each row using a reasonable naming convention
+;; our code knows to use value<i> exactly for combinations with match<i>
+(define-fun vrf0 () Bool (= vrf 10))
+(define-fun vrf1 () Bool (= vrf 20))
+
+;; Combinations
+;;
+;; Our code can ignore combinations that are obviously unsat
+;; for example, table matches that are contradictory
+;; if statements are probably harder.
+;;
+;; Another idea is to invoke the solver incremently
+;; if a prefix of a combination is unsat, all additions to it are also unsat
+;; and can be ignored.
+;;
+(push)
+(echo "combination 1")
+(assert (and port_to_vrf0 vrf0 vrf_ip_to_port0 set_port_if1_then))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 2")
+(assert (and port_to_vrf0 vrf0 vrf_ip_to_port0 set_port_if1_else))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 3")
+(assert (and port_to_vrf0 vrf0 vrf_ip_to_port1 set_port_if1_then))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 4")
+(assert (and port_to_vrf0 vrf0 vrf_ip_to_port1 set_port_if1_else))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 5")
+(assert (and port_to_vrf1 vrf1 vrf_ip_to_port2 set_port_if1_then))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 6")
+(assert (and port_to_vrf1 vrf1 vrf_ip_to_port2 set_port_if1_else))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+

--- a/z3-samples/paths/paths.p4
+++ b/z3-samples/paths/paths.p4
@@ -1,0 +1,173 @@
+/* -*- P4_16 -*- */
+#include <core.p4>
+#include <v1model.p4>
+
+const bit<16> TYPE_IPV4 = 0x800;
+
+/*************************************************************************
+*********************** H E A D E R S  ***********************************
+*************************************************************************/
+
+typedef bit<9>  egressSpec_t;
+typedef bit<48> macAddr_t;
+typedef bit<32> ip4Addr_t;
+
+header ethernet_t {
+    macAddr_t dstAddr;
+    macAddr_t srcAddr;
+    bit<16>   etherType;
+}
+
+header ipv4_t {
+    bit<4>    version;
+    bit<4>    ihl;
+    bit<8>    diffserv;
+    bit<16>   totalLen;
+    bit<16>   identification;
+    bit<3>    flags;
+    bit<13>   fragOffset;
+    bit<8>    ttl;
+    bit<8>    protocol;
+    bit<16>   hdrChecksum;
+    ip4Addr_t srcAddr;
+    ip4Addr_t dstAddr;
+}
+
+struct metadata {
+    bit<8>    vrf;
+}
+
+struct headers {
+    ethernet_t   ethernet;
+    ipv4_t       ipv4;
+}
+
+/*************************************************************************
+*********************** P A R S E R  ***********************************
+*************************************************************************/
+
+parser MyParser(packet_in packet,
+                out headers hdr,
+                inout metadata meta,
+                inout standard_metadata_t standard_metadata) {
+
+    state start {
+        transition parse_ethernet;
+    }
+
+    state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            TYPE_IPV4: parse_ipv4;
+            default: accept;
+        }
+    }
+
+    state parse_ipv4 {
+        packet.extract(hdr.ipv4);
+        transition accept;
+    }
+
+}
+
+/*************************************************************************
+************   C H E C K S U M    V E R I F I C A T I O N   *************
+*************************************************************************/
+
+control MyVerifyChecksum(inout headers hdr, inout metadata meta) {   
+    apply {  }
+}
+
+
+/*************************************************************************
+**************  I N G R E S S   P R O C E S S I N G   *******************
+*************************************************************************/
+
+control MyIngress(inout headers hdr,
+                  inout metadata meta,
+                  inout standard_metadata_t standard_metadata) {
+    action drop() {
+        mark_to_drop(standard_metadata);
+    }
+    
+    action set_port(PortId_t new_port) {
+        if (hdr.ipv4.dstAddr == 10.10.0.0) {
+            standard_metadata.egress_spec = 0;
+        } else {
+            standard_metadata.egress_spec = new_port;
+        }
+    }
+    
+    action set_vrf(bit<8> vrf) {
+        metadata.vrf = vrf;
+        vrf_ip_to_port.apply();
+    }
+
+    table vrf_ip_to_port {
+        key = {
+            hdr.ipv4.dstAddr: lpm;
+            meta.vrf: exact;
+        }
+        actions = {
+            set_port;
+            drop;
+        }
+        size = 1024;
+        default_action = drop();
+    }
+    
+    table port_to_vrf {
+        key = {
+            standard_metadata.ingress_port: exact;
+        }
+        actions = {
+            set_vrf;
+            drop;
+        }
+        size = 1024;
+        default_action = drop();
+    }
+    
+    apply {
+        port_to_vrf.apply();
+    }
+}
+
+/*************************************************************************
+****************  E G R E S S   P R O C E S S I N G   *******************
+*************************************************************************/
+
+control MyEgress(inout headers hdr,
+                 inout metadata meta,
+                 inout standard_metadata_t standard_metadata) {
+    apply {  }
+}
+
+/*************************************************************************
+*************   C H E C K S U M    C O M P U T A T I O N   **************
+*************************************************************************/
+
+control MyComputeChecksum(inout headers  hdr, inout metadata meta) {
+    apply {  }
+}
+
+/*************************************************************************
+***********************  D E P A R S E R  *******************************
+*************************************************************************/
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {  }
+}
+
+/*************************************************************************
+***********************  S W I T C H  *******************************
+*************************************************************************/
+
+V1Switch(
+MyParser(),
+MyVerifyChecksum(),
+MyIngress(),
+MyEgress(),
+MyComputeChecksum(),
+MyDeparser()
+) main;

--- a/z3-samples/paths/paths.p4rt
+++ b/z3-samples/paths/paths.p4rt
@@ -1,0 +1,6 @@
+table_add port_to_vrf set_vrf 0 => 10
+table_add port_to_vrf set_vrf 1 => 20
+
+table_add vrf_ip_to_port set_vrf 10.10.0.0/24 10 => 1
+table_add vrf_ip_to_port set_vrf 10.10.0.0/16 10 => 2
+table_add vrf_ip_to_port set_vrf 20.20.0.0/16 20 => 3

--- a/z3-samples/port-table/sample.smt2
+++ b/z3-samples/port-table/sample.smt2
@@ -7,6 +7,12 @@
 ;;
 (declare-const ingress_port Int)
 
+;; Define un-interpreted constants that constitute an output
+;; packet. At the end of the program, we will define some
+;; constraints on this constant guided by the program flow
+;; and the table entries
+(declare-const egress_spec Int)
+
 ;; Define an interpreted function (i.e. just an alias) per
 ;; row in the table.
 ;;
@@ -53,9 +59,22 @@
 ;; to a table match side effect (e.g. params)
 ;;
 
+;; We define restrictions/constraints on output attributes here,
+;; this should also be done for other intermediate attributes
+;; such as action inputs from table row matches.
+;;
+(assert (= egress_spec
+    (ite ports_exact0 1
+        (ite ports_exact1 0
+            -1
+        )
+    )
+))
+
 ;; We should define aliases for important properties/restrictions here.
 ;; Things like packet validity, not being dropped, etc.
 ;;
+(define-fun not_dropped () Bool (not (= egress_spec -1)))
 
 ;; Finally, we need to have combinations of the above defined quantities
 ;; representing combinations of code paths and table hits.
@@ -84,5 +103,42 @@
 (get-model)
 (echo "")
 (pop)
+
+;; Alternatively, we can ask for a packet that has output port 1
+;;
+(push)
+(echo "output = 1")
+(assert (= egress_spec 1))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+;; Or, we can simulate what will happen to an input packet on port 1
+(push)
+(echo "input = 1")
+(assert (= ingress_port 1))
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+;; Finally, we can determine if a packet is valid/not dropped, or ask
+;; for an arbitrary valid one
+(push)
+(echo "Is packet with input port 5 valid/not-dropped?")
+(assert (and (= ingress_port 5) not_dropped))
+(check-sat)
+(echo "")
+(pop)
+
+(push)
+(echo "Get any valid/not dropped packet")
+(assert not_dropped)
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
 
 

--- a/z3-samples/port-table/sample.smt2
+++ b/z3-samples/port-table/sample.smt2
@@ -1,0 +1,88 @@
+;; Define un-interpreted constants that constitute a packet
+;; the exact definition should depend on the headers and
+;; metadata defined/used in the p4 program.
+;;
+;; It is probably a good idea to keep the names of theses
+;; constants similar to the attribute names from p4
+;;
+(declare-const ingress_port Int)
+
+;; Define an interpreted function (i.e. just an alias) per
+;; row in the table.
+;;
+;; The body of the function uses the packet constants, such
+;; the body is true iff the corresponding entry is hit by the
+;; corresponding packet.
+;;
+;; The table definition should tell us which types to use and
+;; what kind of logical operations should be performed (exact, LPM)
+;; the values of the table entries can tell us what the concrete
+;; values in these logical operations are.
+;;
+;; Later, we should consider using quantified variables instead
+;; of values to abstract away from concrete table entries.
+;;
+;; These functions must be so that any given packet can only satisfy
+;; no more than one function. An easy way to do this is to and
+;; the function body with the negation of every other function.
+;; that is probably inefficient, and can cause problems with cyclic
+;; definitions. A better way is to do this by design, e.g. by taking
+;; into consideration LPM and priorities inline.
+;;
+;; A good naming convention is to use the table name with the index
+;; of the table entry
+;;
+;;
+;; When parsing the p4 program, if we find table dependence (e.g. vrf)
+;; then the dependent table functions should reference the depending
+;; table functions in their body.
+;;
+;; This simple mechanism should be extended to handle entries
+;; pointing to different actions and providing different parameters
+;; actions likely do not need to be reflected here beyond as aliases
+;; parameters are important depending on their use within the action
+(define-fun ports_exact0 () Bool (= ingress_port 0))
+(define-fun ports_exact1 () Bool (= ingress_port 1))
+
+;; Any branching within the code should also be reflected here,
+;; likely as function aliases similar to the above. For example,
+;; an if statement with two branches should result in two functions
+;; indicating which branch was taken.
+;;
+;; A branch's side effects likely need to be encoded in a way similar
+;; to a table match side effect (e.g. params)
+;;
+
+;; We should define aliases for important properties/restrictions here.
+;; Things like packet validity, not being dropped, etc.
+;;
+
+;; Finally, we need to have combinations of the above defined quantities
+;; representing combinations of code paths and table hits.
+;;
+;; This should likely be generated via some cross-product like iteration
+;; in our code, over all table entries from different tables and code branches,
+;; guided by the parsed program trace/flow.
+;;
+;; For performance reasons, we should exclude clearly unreachable combinations.
+;; For example, a table match that invokes an action with an if branch in a different
+;; un-invoked action. However, not excluding them should not affect correctness,
+;; the SMT solver should return unsat for such combinations
+;;
+(push)
+(echo "combination 1")
+(assert ports_exact0)
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+(push)
+(echo "combination 2")
+(assert ports_exact1)
+(check-sat)
+(get-model)
+(echo "")
+(pop)
+
+


### PR DESCRIPTION
* Find sample test packets for table-port sample program
* Find sample test packets for program/p4rt entries that include 2
tables applied consecutively, using a table output parameter as a match
for the next table, if statement, and overlaping LPM entries.