### PR TITLE
Auto Formatting and CI Tests

### DIFF
--- a/.github/workflows/ci-bmv2-test.yml
+++ b/.github/workflows/ci-bmv2-test.yml
@@ -1,0 +1,23 @@
+name: "Bmv2 JSON subset and golden file tests"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Build Docker image
+      run: docker build --tag p4-symbolic .
+
+    - name: Bmv2 JSON parsing test
+      env:
+        TEST: bazel test //p4_symbolic/bmv2/... --test_output=errors
+      run: docker run --tty p4-symbolic $TEST

--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -1,0 +1,31 @@
+name: "format"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        
+    - name: Run format.sh
+      run: ./format.sh
+
+    - name: Check formatting diff
+      run: |
+        CHANGED_FILES="$(git diff-index --name-only HEAD --)"
+        if [[ -z "${CHANGED_FILES}" ]]; then
+          echo "Success: no formatting changes needed."
+          exit 0
+        fi
+        echo "Found formatting changes in the following files:"
+        echo "${CHANGED_FILES}"
+        echo ""
+        echo "Please run format.sh to apply the changes."
+        exit 1

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,1 +1,8 @@
-# Intentionally left blank.
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
+# Bazel buildifier: auto formats bazel files.
+buildifier(
+    name = "buildifier",
+    exclude_patterns = ["./third_party/**"],
+    lint_mode = "fix",
+)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM p4lang/p4c:latest
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY . /p4-symbolic/
+WORKDIR /p4-symbolic/
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends \
+  wget \
+  ca-certificates \
+  build-essential \
+  python3 \
+  libgmp-dev \
+  git
+RUN update-ca-certificates
+
+RUN wget "https://github.com/bazelbuild/bazelisk/releases/download/v1.4.0/bazelisk-linux-amd64"
+RUN chmod +x bazelisk-linux-amd64
+RUN ln -s $(pwd)/bazelisk-linux-amd64 /usr/local/bin/bazel

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -12,17 +12,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Buildtools (and dependencies). This Include buildifier, bazel's auto
+# formatting/linting.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# absl
 http_archive(
-  name = "com_google_absl",
-  urls = ["https://github.com/abseil/abseil-cpp/archive/c512f118dde6ffd51cb7d8ac8804bbaf4d266c3a.zip"],
-  strip_prefix = "abseil-cpp-c512f118dde6ffd51cb7d8ac8804bbaf4d266c3a",
-  sha256 = "8400c511d64eb4d26f92c5ec72535ebd0f843067515244e8b50817b0786427f9",
+    name = "io_bazel_rules_go",
+    sha256 = "a8d6b1b354d371a646d2f7927319974e0f9e52f73a2452d2b3877118169eb6bb",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.23.3/rules_go-v0.23.3.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.23.3/rules_go-v0.23.3.tar.gz",
+    ],
 )
 
-# rules_cc defines rules for generating C++ code from Protocol Buffers
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains()
+
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "cdb02a887a7187ea4d5a27452311a75ed8637379a1287d8eeb952138ea485f7d",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.21.1/bazel-gazelle-v0.21.1.tar.gz",
+    ],
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+# Workaround for WORKSPACE.bazel.
+# See https://github.com/bazelbuild/bazel-gazelle/issues/678
+gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
+
+http_archive(
+    name = "com_github_bazelbuild_buildtools",
+    strip_prefix = "buildtools-master",
+    url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
+)
+
+# Google's absl library.
+http_archive(
+    name = "com_google_absl",
+    sha256 = "8400c511d64eb4d26f92c5ec72535ebd0f843067515244e8b50817b0786427f9",
+    strip_prefix = "abseil-cpp-c512f118dde6ffd51cb7d8ac8804bbaf4d266c3a",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/c512f118dde6ffd51cb7d8ac8804bbaf4d266c3a.zip"],
+)
+
+# "rules_cc" defines rules for generating C++ code from Protocol Buffers.
 http_archive(
     name = "rules_cc",
     sha256 = "35f2fb4ea0b3e61ad64a369de284e4fbbdcdba71836a5555abb5e194cf119509",
@@ -33,7 +71,7 @@ http_archive(
     ],
 )
 
-# rules_proto defines abstract rules for building Protocol Buffers
+# "rules_proto" defines abstract rules for building Protocol Buffers.
 http_archive(
     name = "rules_proto",
     sha256 = "2490dca4f249b8a9a3ab07bd1ba6eca085aaf8e45a734af92aad0c42d9dc7aaf",
@@ -45,8 +83,11 @@ http_archive(
 )
 
 load("@rules_cc//cc:repositories.bzl", "rules_cc_dependencies")
+
 rules_cc_dependencies()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
 rules_proto_dependencies()
+
 rules_proto_toolchains()

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Formats source files according to Google's style guide. Requires clang-format.
+
+# Only files with these extensions will be formatted by clang-format.
+CLANG_FORMAT_EXTENSIONS="cc|h|proto"
+
+# Run clang-format.
+find . -not -path "./third_party/**" \
+  | egrep "\.(${CLANG_FORMAT_EXTENSIONS})\$" \
+  | xargs clang-format --verbose -style=google -i
+
+# Run buildifier (Bazel file formatter).
+bazel run //:buildifier

--- a/p4_symbolic/bmv2/BUILD.bazel
+++ b/p4_symbolic/bmv2/BUILD.bazel
@@ -17,56 +17,53 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
-
-# Load our testing rules and run_p4c rule.
-load("//:p4c.bzl", "run_p4c")
 load("//p4_symbolic/bmv2:test.bzl", "bmv2_protobuf_parsing_test")
 
 # Rules for building protobuf.
 cc_proto_library(
     name = "bmv2_cc_proto",
+    visibility = ["//p4_symbolic:__pkg__"],
     deps = [":bmv2_proto"],
-    visibility = ["//p4_symbolic:__pkg__"]
 )
 
 proto_library(
     name = "bmv2_proto",
     srcs = [
-      "bmv2.proto"
+        "bmv2.proto",
     ],
     deps = [
-      "@com_google_protobuf//:struct_proto",
-    ]
+        "@com_google_protobuf//:struct_proto",
+    ],
 )
 
 # Rules for building test.cc binary.
 cc_binary(
     name = "test",
     srcs = ["test.cc"],
-    deps = [":bmv2_cc_proto"]
+    deps = [":bmv2_cc_proto"],
 )
 
 # Test rules: one per program in //p4-samples
 bmv2_protobuf_parsing_test(
     name = "port_table",
+    golden_file = "expected/table.pb.txt",
     p4_program = "//p4-samples:port-table/table.p4",
-    golden_file = "expected/table.pb.txt"
 )
 
 bmv2_protobuf_parsing_test(
     name = "ipv4_routing",
+    golden_file = "expected/basic.pb.txt",
     p4_program = "//p4-samples:ipv4-routing/basic.p4",
-    golden_file = "expected/basic.pb.txt"
 )
 
 bmv2_protobuf_parsing_test(
     name = "port_hardcoded",
+    golden_file = "expected/hardcoded.pb.txt",
     p4_program = "//p4-samples:hardcoded/hardcoded.p4",
-    golden_file = "expected/hardcoded.pb.txt"
 )
 
 bmv2_protobuf_parsing_test(
     name = "reflector",
+    golden_file = "expected/reflector.pb.txt",
     p4_program = "//p4-samples:reflector/reflector.p4",
-    golden_file = "expected/reflector.pb.txt"
 )

--- a/p4_symbolic/bmv2/bmv2.proto
+++ b/p4_symbolic/bmv2/bmv2.proto
@@ -113,7 +113,7 @@ message ParserTransition {
   // this transition is applied or not.
   string value = 1;
   // The type of the value above, usually a hex string.
-  string type = 2; // TODO(babman): turn into Enum
+  string type = 2;  // TODO(babman): turn into Enum
   // Any mask applied by the transition, if no mask is applied,
   // protobuf will parse this as "".
   string mask = 3;

--- a/p4_symbolic/bmv2/expected/basic.pb.txt
+++ b/p4_symbolic/bmv2/expected/basic.pb.txt
@@ -393,14 +393,14 @@ parsers {
       next_state: "parse_ipv4"
     }
     transitions {
-      value: "default"
+      type: "default"
     }
   }
   parse_states {
     name: "parse_ipv4"
     id: 1
     transitions {
-      value: "default"
+      type: "default"
     }
   }
 }

--- a/p4_symbolic/bmv2/expected/hardcoded.pb.txt
+++ b/p4_symbolic/bmv2/expected/hardcoded.pb.txt
@@ -207,7 +207,7 @@ parsers {
   parse_states {
     name: "start"
     transitions {
-      value: "default"
+      type: "default"
     }
   }
 }
@@ -221,7 +221,7 @@ deparsers {
   }
 }
 actions {
-  name: "act"
+  name: "hardcoded55"
   primitives {
     fields {
       key: "op"
@@ -309,7 +309,7 @@ actions {
   }
 }
 actions {
-  name: "act_0"
+  name: "hardcoded57"
   id: 1
   primitives {
     fields {
@@ -407,7 +407,7 @@ pipelines {
   }
   init_table: "node_2"
   tables {
-    name: "tbl_act"
+    name: "tbl_hardcoded55"
     source_info {
       filename: "p4-samples/hardcoded/hardcoded.p4"
       line: 55
@@ -418,10 +418,10 @@ pipelines {
     type: "simple"
     max_size: 1024
     action_ids: 0
-    actions: "act"
+    actions: "hardcoded55"
   }
   tables {
-    name: "tbl_act_0"
+    name: "tbl_hardcoded57"
     id: 1
     source_info {
       filename: "p4-samples/hardcoded/hardcoded.p4"
@@ -433,7 +433,7 @@ pipelines {
     type: "simple"
     max_size: 1024
     action_ids: 1
-    actions: "act_0"
+    actions: "hardcoded57"
   }
 }
 pipelines {

--- a/p4_symbolic/bmv2/expected/reflector.pb.txt
+++ b/p4_symbolic/bmv2/expected/reflector.pb.txt
@@ -207,7 +207,7 @@ parsers {
   parse_states {
     name: "start"
     transitions {
-      value: "default"
+      type: "default"
     }
   }
 }
@@ -221,7 +221,7 @@ deparsers {
   }
 }
 actions {
-  name: "act"
+  name: "reflector54"
   primitives {
     fields {
       key: "op"
@@ -323,9 +323,9 @@ pipelines {
     column: 8
     source_fragment: "MyIngress"
   }
-  init_table: "tbl_act"
+  init_table: "tbl_reflector54"
   tables {
-    name: "tbl_act"
+    name: "tbl_reflector54"
     source_info {
       filename: "p4-samples/reflector/reflector.p4"
       line: 54
@@ -336,7 +336,7 @@ pipelines {
     type: "simple"
     max_size: 1024
     action_ids: 0
-    actions: "act"
+    actions: "reflector54"
   }
 }
 pipelines {

--- a/p4_symbolic/bmv2/expected/table.pb.txt
+++ b/p4_symbolic/bmv2/expected/table.pb.txt
@@ -207,7 +207,7 @@ parsers {
   parse_states {
     name: "start"
     transitions {
-      value: "default"
+      type: "default"
     }
   }
 }

--- a/p4_symbolic/bmv2/test.bzl
+++ b/p4_symbolic/bmv2/test.bzl
@@ -58,13 +58,13 @@ def _exact_diff_impl(ctx):
             actual = ctx.file.actual.short_path,
             expected = ctx.file.expected.short_path,
             package = ctx.label.package,
-            name = ctx.label.name
-        )
+            name = ctx.label.name,
+        ),
     )
 
     runfiles = [ctx.file.actual, ctx.file.expected]
     return DefaultInfo(
-        runfiles = ctx.runfiles(files = runfiles)
+        runfiles = ctx.runfiles(files = runfiles),
     )
 
 exact_diff_test = rule(
@@ -88,8 +88,8 @@ exact_diff_test = rule(
             doc = "Expected file (aka golden file).",
             mandatory = True,
             allow_single_file = True,
-        )
-    }
+        ),
+    },
 )
 
 # Performs a subset diff between an actual (the subset) and
@@ -100,13 +100,13 @@ def _subset_diff_impl(ctx):
         content = "python {sdiff_py} {expected} {actual}".format(
             sdiff_py = ctx.file._sdiff_py.short_path,
             expected = ctx.file.expected.short_path,
-            actual = ctx.file.actual.short_path
-        )
+            actual = ctx.file.actual.short_path,
+        ),
     )
 
     runfiles = [ctx.file._sdiff_py, ctx.file.actual, ctx.file.expected]
     return DefaultInfo(
-        runfiles = ctx.runfiles(files = runfiles)
+        runfiles = ctx.runfiles(files = runfiles),
     )
 
 subset_diff_test = rule(
@@ -154,7 +154,7 @@ subset_diff_test = rule(
         "actual": attr.label(
             doc = "The dumped protobuf JSON file, or a rule producing it.",
             mandatory = True,
-            allow_single_file = True
+            allow_single_file = True,
         ),
         "expected": attr.label(
             doc = """
@@ -162,15 +162,15 @@ subset_diff_test = rule(
                 rule producing it.
                 """,
             mandatory = True,
-            allow_single_file = True
+            allow_single_file = True,
         ),
         "_sdiff_py": attr.label(
             doc = "The diff python script file.",
             mandatory = False,
             allow_single_file = True,
-            default = "test_sdiff.py"
-        )
-    }
+            default = "test_sdiff.py",
+        ),
+    },
 )
 
 # Macro that defines subset and exact diff rules for a given p4 program
@@ -187,7 +187,7 @@ subset_diff_test = rule(
 # 5. A test suite combining both 4 and 5.
 # Use the p4_deps list to specify dependent files that p4_program input
 # file depends on (e.g. by including them).
-def bmv2_protobuf_parsing_test(name, p4_program, golden_file, p4_deps=[]):
+def bmv2_protobuf_parsing_test(name, p4_program, golden_file, p4_deps = []):
     p4c_name = "%s_p4c" % name
     parse_name = "%s_parse" % name
     exact_diff_name = "%s_exact_test" % name
@@ -197,7 +197,7 @@ def bmv2_protobuf_parsing_test(name, p4_program, golden_file, p4_deps=[]):
     run_p4c(
         name = p4c_name,
         src = p4_program,
-        deps = p4_deps
+        deps = p4_deps,
     )
 
     # Use p4_symbolic/main.cc to parse input json and dump
@@ -211,21 +211,21 @@ def bmv2_protobuf_parsing_test(name, p4_program, golden_file, p4_deps=[]):
         tools = ["//p4_symbolic/bmv2:test"],
         cmd = """
             $(location //p4_symbolic/bmv2:test) $(OUTS) < $(SRCS)
-            """
+            """,
     )
 
     # Subset diff test between output and input json files
     subset_diff_test(
         name = subset_diff_name,
         actual = json_filename,
-        expected = ":" + p4c_name
+        expected = ":" + p4c_name,
     )
 
     # Exact diff test between output and golden protobuf files.
     exact_diff_test(
         name = exact_diff_name,
         actual = proto_filename,
-        expected = golden_file
+        expected = golden_file,
     )
 
     # Group tests into a test_suite with the given name.
@@ -234,6 +234,6 @@ def bmv2_protobuf_parsing_test(name, p4_program, golden_file, p4_deps=[]):
         name = name,
         tests = [
             ":" + subset_diff_name,
-            ":" + exact_diff_name
-        ]
+            ":" + exact_diff_name,
+        ],
     )

--- a/p4_symbolic/bmv2/test.cc
+++ b/p4_symbolic/bmv2/test.cc
@@ -19,13 +19,12 @@
 // The dumps are written to output files whose paths are provided as command
 // line arguments.
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 
-#include "google/protobuf/util/json_util.h"
 #include "google/protobuf/text_format.h"
-
+#include "google/protobuf/util/json_util.h"
 #include "p4_symbolic/bmv2/bmv2.pb.h"
 
 // Read all of stdin up to EOF.
@@ -55,7 +54,7 @@ int main(int argc, char* argv[]) {
   // Validate command line arguments.
   if (argc != 3) {
     std::cout << "Usage: ./main <protobuf output file> <json output file>."
-        << std::endl;
+              << std::endl;
     return 0;
   }
 
@@ -80,8 +79,7 @@ int main(int argc, char* argv[]) {
   dumping_options.preserve_proto_field_names = true;
 
   std::string json_output_str;
-  google::protobuf::util::MessageToJsonString(p4_buf,
-                                              &json_output_str,
+  google::protobuf::util::MessageToJsonString(p4_buf, &json_output_str,
                                               dumping_options);
   WriteFile(argv[2], json_output_str);
 

--- a/p4c.bzl
+++ b/p4c.bzl
@@ -24,8 +24,8 @@ def _run_p4c_impl(ctx):
         if ctx.attr.target == "bmv2":
             extension = ".json"
         else:
-            fail("Extension is not provided for unknown target %s"
-                % ctx.attr.target)
+            fail("Extension is not provided for unknown target %s" %
+                 ctx.attr.target)
 
     # The output file path (relative to the directory of the src input file).
     fname = "".join([
@@ -33,7 +33,7 @@ def _run_p4c_impl(ctx):
         "-bazel-p4c-tmp-output/",
         # Base name without the .p4 extension.
         ctx.file.src.basename[:-3],
-        extension
+        extension,
     ])
 
     # Declare the output file.
@@ -43,7 +43,7 @@ def _run_p4c_impl(ctx):
     # the output file.
     # This is needed because p4c expects a directory to be passed with "-o".
     # P4c will put the output file in that directory.
-    output_dir_path = output_file.path[:-len(output_file.basename)-1]
+    output_dir_path = output_file.path[:-len(output_file.basename) - 1]
 
     # Run p4c.
     ctx.actions.run_shell(
@@ -57,8 +57,8 @@ def _run_p4c_impl(ctx):
             ctx.attr.arch,
             output_dir_path,
             ctx.attr.p4c_args,
-            ctx.file.src.path
-        ]
+            ctx.file.src.path,
+        ],
     )
 
     return [DefaultInfo(files = depset([output_file]))]
@@ -70,34 +70,34 @@ run_p4c = rule(
         "src": attr.label(
             doc = "Input .p4 files to pass to p4c.",
             mandatory = True,
-            allow_single_file = [".p4"]
+            allow_single_file = [".p4"],
         ),
         "deps": attr.label_list(
             doc = "Other dependent files/labels. Use for included p4 files.",
             mandatory = False,
             allow_empty = True,
             allow_files = [".p4"],
-            default = []
+            default = [],
         ),
         "target": attr.string(
             doc = "The --target argument passed to p4c (default: bmv2).",
             mandatory = False,
-            default = "bmv2"
+            default = "bmv2",
         ),
         "arch": attr.string(
             doc = "The --arch argument passed to p4v (default: v1model).",
             mandatory = False,
-            default = "v1model"
+            default = "v1model",
         ),
         "std": attr.string(
             doc = "The --std argument passed to p4v (default: p4_16).",
             mandatory = False,
-            default = "p4_16"
+            default = "p4_16",
         ),
         "p4c_args": attr.string(
             doc = "Any additional command line arguments to pass to p4c.",
             mandatory = False,
-            default = ""
+            default = "",
         ),
         "extension": attr.string(
             doc = """
@@ -108,7 +108,7 @@ run_p4c = rule(
                 throw an Error if it was not able to determine it.
                 """,
             mandatory = False,
-            default = ""
-        )
+            default = "",
+        ),
     },
 )


### PR DESCRIPTION
This PR adds auto formatting scripts and github workflows for CI testing.

Formatting:
* buildifier rule is used to auto format and lint bazel files.
* clang-format with -style=google is used to format .cc/.h/.proto files.
* /format.sh is the main formatting script, which executes clang-format and buildifier.

CI:
* formatting github action runs /format.sh and accepts if no files were changed.
* bmv2 runs all bmv2 subset and golden files tests with `bazel test //p4_symbolic/bmv2/...`.
* workflows are configured to execute on every push and pull request to master.

Similar to https://github.com/p4lang/p4-constraints/tree/master/.github/workflows