### PR TITLE
Clean up p4-samples stop rule

### DIFF
--- a/p4-samples/Makefile
+++ b/p4-samples/Makefile
@@ -71,8 +71,10 @@ packets: $(TCPDUMP_PID)
 stop: kill clean
 
 kill:
-	@sudo kill `cat $(SIMPLE_SWITCH_PID)` && sudo rm $(SIMPLE_SWITCH_PID)
-	@sudo kill `cat $(TCPDUMP_PID)` && rm $(TCPDUMP_PID)
+	@sudo kill `cat $(SIMPLE_SWITCH_PID)` || echo "simple switch is not running!"
+	@sudo rm -f $(SIMPLE_SWITCH_PID)
+	@sudo kill `cat $(TCPDUMP_PID)` || echo "tcpdump is not running!"
+	@sudo rm -f $(TCPDUMP_PID)
 
 clean:
 	@rm -f *.json *.p4i *.log *.info.*


### PR DESCRIPTION
Previous rule would fail if either of simple_switch or tcpdump were stopped manualy/previously or crashed. If the rule failed, the entire stop flow, which includes stopping other processes and cleaning up log and tmp files is stopped.

Instead, the rule is modified so the workflow survives such failure, outputs a warning, and keeps going.