### PR TITLE
Use enums where appropriate in bmv2 protobuf instead of strings

### DIFF
--- a/p4_symbolic/bmv2/BUILD.bazel
+++ b/p4_symbolic/bmv2/BUILD.bazel
@@ -22,7 +22,7 @@ load("//p4_symbolic/bmv2:test.bzl", "bmv2_protobuf_parsing_test")
 # Rules for building protobuf.
 cc_proto_library(
     name = "bmv2_cc_proto",
-    visibility = ["//p4_symbolic:__pkg__"],
+    visibility = ["//p4_symbolic:__subpackages__"],
     deps = [":bmv2_proto"],
 )
 
@@ -31,6 +31,7 @@ proto_library(
     srcs = [
         "bmv2.proto",
     ],
+    visibility = ["//p4_symbolic:__subpackages__"],
     deps = [
         "@com_google_protobuf//:struct_proto",
     ],

--- a/p4_symbolic/bmv2/bmv2.proto
+++ b/p4_symbolic/bmv2/bmv2.proto
@@ -49,7 +49,6 @@ enum ParserTransitionTypeEnum {
 
 // The type of a table.
 // Determines where actions are defined and how they get selected.
-// This is always "simple" in all our sample programs.
 enum TableTypeEnum {
   simple = 0;       // A Simple key and action table.
   indirect = 1;     // Action profiles table.

--- a/p4_symbolic/bmv2/bmv2.proto
+++ b/p4_symbolic/bmv2/bmv2.proto
@@ -25,6 +25,37 @@ package p4_symbolic.bmv2;
 
 import "google/protobuf/struct.proto";
 
+// Acceptable values for match type of keys of a table.
+enum TableMatchTypeEnum {
+  // Casing must match the bmv2 json!
+  exact = 0;
+  lpm = 1;
+  ternary = 2;
+  range = 3;
+}
+
+// The type (of the match) of a parser transition.
+enum ParserTransitionTypeEnum {
+  // The default transition (no matching).
+  default = 0;
+  // Transition is applied when hex strings match.
+  // The match hex string and the matched field are defined
+  // in ParserTransition.
+  hexstr = 1;
+  // Matching via a named parse value set.
+  // The name of the value set is defined in ParserTransition.
+  parse_vset = 2;
+}
+
+// The type of a table.
+// Determines where actions are defined and how they get selected.
+// This is always "simple" in all our sample programs.
+enum TableTypeEnum {
+  simple = 0;       // A Simple key and action table.
+  indirect = 1;     // Action profiles table.
+  indirect_ws = 2;  // Action profiles with dynamic selector.
+}
+
 // Specifies the overal structure of a p4 program json
 // file outputed by p4c with a bmv2 target.
 // Several fields may not be present in this specification
@@ -111,9 +142,10 @@ message ParserState {
 message ParserTransition {
   // The value of the condition/match dictating whether
   // this transition is applied or not.
+  // A hexstring or a parser value set depending on the type.
   string value = 1;
   // The type of the value above, usually a hex string.
-  string type = 2;  // TODO(babman): turn into Enum
+  ParserTransitionTypeEnum type = 2;
   // Any mask applied by the transition, if no mask is applied,
   // protobuf will parse this as "".
   string mask = 3;
@@ -170,11 +202,10 @@ message Table {
   // There is always a most general match because of P4 restrications
   // on match combination (which may be under-documented).
   // See https://github.com/p4lang/p4-spec/issues/411
-  string match_type = 5;  // TODO(babman): make into an enum
+  TableMatchTypeEnum match_type = 5;
   // This seems to be the "type of the table",
   // in all sample programs it is value is "simple".
-  // TODO(babman): investigate what simple means and what other options exist.
-  string type = 6;
+  TableTypeEnum type = 6;
   // The maximum size of the table (in number of entries).
   int32 max_size = 7;
   // Actions and action_ids are index matching arrays
@@ -191,7 +222,8 @@ message TableKey {
   // The kind of match applied by this key when the table
   // is applied to a packet.
   // This can be 'exact', 'lpm', 'ternary'.
-  string match_type = 1;  // TODO(babman): make into an enum (same as in Table).
+  // TODO(babman): this might also be "valid".
+  TableMatchTypeEnum match_type = 1;
   // This is essentially a string representation of the target.
   // e.g. standard_metadata.ingress_port.
   string name = 2;

--- a/p4_symbolic/bmv2/expected/basic.pb.txt
+++ b/p4_symbolic/bmv2/expected/basic.pb.txt
@@ -389,18 +389,16 @@ parsers {
     name: "start"
     transitions {
       value: "0x0800"
-      type: "hexstr"
+      type: hexstr
       next_state: "parse_ipv4"
     }
     transitions {
-      type: "default"
     }
   }
   parse_states {
     name: "parse_ipv4"
     id: 1
     transitions {
-      type: "default"
     }
   }
 }
@@ -969,13 +967,12 @@ pipelines {
       source_fragment: "ipv4_lpm"
     }
     key {
-      match_type: "lpm"
+      match_type: lpm
       name: "hdr.ipv4.dstAddr"
       target: "ipv4"
       target: "dstAddr"
     }
-    match_type: "lpm"
-    type: "simple"
+    match_type: lpm
     max_size: 1024
     action_ids: 2
     action_ids: 1

--- a/p4_symbolic/bmv2/expected/hardcoded.pb.txt
+++ b/p4_symbolic/bmv2/expected/hardcoded.pb.txt
@@ -207,7 +207,6 @@ parsers {
   parse_states {
     name: "start"
     transitions {
-      type: "default"
     }
   }
 }
@@ -414,8 +413,6 @@ pipelines {
       column: 42
       source_fragment: "="
     }
-    match_type: "exact"
-    type: "simple"
     max_size: 1024
     action_ids: 0
     actions: "hardcoded55"
@@ -429,8 +426,6 @@ pipelines {
       column: 42
       source_fragment: "="
     }
-    match_type: "exact"
-    type: "simple"
     max_size: 1024
     action_ids: 1
     actions: "hardcoded57"

--- a/p4_symbolic/bmv2/expected/reflector.pb.txt
+++ b/p4_symbolic/bmv2/expected/reflector.pb.txt
@@ -207,7 +207,6 @@ parsers {
   parse_states {
     name: "start"
     transitions {
-      type: "default"
     }
   }
 }
@@ -332,8 +331,6 @@ pipelines {
       column: 38
       source_fragment: "="
     }
-    match_type: "exact"
-    type: "simple"
     max_size: 1024
     action_ids: 0
     actions: "reflector54"

--- a/p4_symbolic/bmv2/expected/table.pb.txt
+++ b/p4_symbolic/bmv2/expected/table.pb.txt
@@ -207,7 +207,6 @@ parsers {
   parse_states {
     name: "start"
     transitions {
-      type: "default"
     }
   }
 }
@@ -334,13 +333,10 @@ pipelines {
       source_fragment: "ports_exact"
     }
     key {
-      match_type: "exact"
       name: "standard_metadata.ingress_port"
       target: "standard_metadata"
       target: "ingress_port"
     }
-    match_type: "exact"
-    type: "simple"
     max_size: 1024
     action_ids: 1
     action_ids: 0


### PR DESCRIPTION
* update expected test files
* update visibility of bmv2 protobuf build rules