### PR TITLE
Parsing Pipeline: Helpful utils and clean to setup parsing pipeline (1/4)

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -54,14 +54,6 @@ http_archive(
     url = "https://github.com/bazelbuild/buildtools/archive/master.zip",
 )
 
-# Google's absl library.
-http_archive(
-    name = "com_google_absl",
-    sha256 = "8400c511d64eb4d26f92c5ec72535ebd0f843067515244e8b50817b0786427f9",
-    strip_prefix = "abseil-cpp-c512f118dde6ffd51cb7d8ac8804bbaf4d266c3a",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/c512f118dde6ffd51cb7d8ac8804bbaf4d266c3a.zip"],
-)
-
 # "rules_cc" defines rules for generating C++ code from Protocol Buffers.
 http_archive(
     name = "rules_cc",

--- a/p4-samples/Makefile
+++ b/p4-samples/Makefile
@@ -30,7 +30,7 @@ COMPILED_FILE_NAMES := $(SOURCE_FILE_NAMES:.p4=.json)
 build: $(COMPILED_FILE_NAMES)
 
 %.json: %.p4
-	p4c --std p4_16 --target bmv2 --arch v1model --p4runtime-files $(basename $@).info.json $<
+	p4c --std p4_16 --target bmv2 --arch v1model --p4runtime-files $(basename $@).pb.txt $<
 
 #
 # bmv2 simulation
@@ -77,7 +77,7 @@ kill:
 	@sudo rm -f $(TCPDUMP_PID)
 
 clean:
-	@rm -f *.json *.p4i *.log *.info.*
+	@rm -f *.json *.p4i *.log *.info.* *.pb.txt
 
 # PHONY rules with names that do not correspond to files
 .PHONY: build simple_switch veth control_plane packets stop kill clean

--- a/p4_symbolic/util/BUILD.bazel
+++ b/p4_symbolic/util/BUILD.bazel
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "util",
+    srcs = [
+        "io.cc",
+        "status.cc",
+    ],
+    hdrs = [
+        "io.h",
+        "status.h",
+    ],
+    visibility = ["//p4_symbolic:__subpackages__"],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_protobuf//:protobuf_headers",
+    ],
+)

--- a/p4_symbolic/util/BUILD.bazel
+++ b/p4_symbolic/util/BUILD.bazel
@@ -29,5 +29,6 @@ cc_library(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf_headers",
+        "@p4_pdpi//p4_pdpi/utils:status_utils",
     ],
 )

--- a/p4_symbolic/util/io.cc
+++ b/p4_symbolic/util/io.cc
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This is a test file for our protobuf specifications of bmv2 json.
-// It reads an input bmv2 json string (usually the output of p4c) via stdin,
-// it parses the string using protobuf, and then dumps the parsed protobuf
-// objects using protobuf text format and json.
-// The dumps are written to output files whose paths are provided as command
-// line arguments.
-
 #include "p4_symbolic/util/io.h"
 
 #include <cerrno>

--- a/p4_symbolic/util/io.cc
+++ b/p4_symbolic/util/io.cc
@@ -1,0 +1,56 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a test file for our protobuf specifications of bmv2 json.
+// It reads an input bmv2 json string (usually the output of p4c) via stdin,
+// it parses the string using protobuf, and then dumps the parsed protobuf
+// objects using protobuf text format and json.
+// The dumps are written to output files whose paths are provided as command
+// line arguments.
+
+#include "p4_symbolic/util/io.h"
+
+#include <cerrno>
+#include <fstream>
+#include <streambuf>
+
+#include "absl/strings/str_format.h"
+
+namespace p4_symbolic {
+namespace util {
+
+absl::Status ReadFile(std::string path, std::string *output) {
+  std::ifstream f;
+  f.open(path.c_str());
+  if (f.fail()) {
+    std::string err;
+    switch (errno) {
+      case EACCES:
+      case ENOENT:
+        err = absl::StrFormat("%s: %s", strerror(errno), path);
+        return absl::Status(absl::StatusCode::kNotFound, err);
+      default:
+        err = absl::StrFormat("Cannot read file %s, errno = %d", path, errno);
+        return absl::Status(absl::StatusCode::kUnknown, err);
+    }
+  }
+
+  f >> std::noskipws;  // Read whitespaces.
+  *output = std::string(std::istreambuf_iterator<char>(f),
+                        std::istreambuf_iterator<char>());
+  return absl::OkStatus();
+}
+
+}  // namespace util
+}  // namespace p4_symbolic

--- a/p4_symbolic/util/io.cc
+++ b/p4_symbolic/util/io.cc
@@ -50,9 +50,8 @@ pdpi::StatusOr<std::string> ReadFile(std::string path) {
   }
 
   f >> std::noskipws;  // Read whitespaces.
-  std::string output(std::istreambuf_iterator<char>(f),
-                     (std::istreambuf_iterator<char>()));
-  return pdpi::StatusOr<std::string>(output);
+  return std::string(std::istreambuf_iterator<char>(f),
+                     std::istreambuf_iterator<char>());
 }
 
 }  // namespace util

--- a/p4_symbolic/util/io.h
+++ b/p4_symbolic/util/io.h
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This is a test file for our protobuf specifications of bmv2 json.
-// It reads an input bmv2 json string (usually the output of p4c) via stdin,
-// it parses the string using protobuf, and then dumps the parsed protobuf
-// objects using protobuf text format and json.
-// The dumps are written to output files whose paths are provided as command
-// line arguments.
-
 #ifndef P4_SYMBOLIC_UTIL_IO_H_
 #define P4_SYMBOLIC_UTIL_IO_H_
 

--- a/p4_symbolic/util/io.h
+++ b/p4_symbolic/util/io.h
@@ -29,7 +29,7 @@
 namespace p4_symbolic {
 namespace util {
 
-// Read the entire content of the file and store it in "output".
+// Read the entire content of the file and return it (or an error status).
 pdpi::StatusOr<std::string> ReadFile(std::string path);
 
 }  // namespace util

--- a/p4_symbolic/util/io.h
+++ b/p4_symbolic/util/io.h
@@ -29,7 +29,7 @@
 namespace p4_symbolic {
 namespace util {
 
-// Read the entire content of the file and return it (or an error status).
+// Reads the entire content of the file and returns it (or an error status).
 pdpi::StatusOr<std::string> ReadFile(std::string path);
 
 }  // namespace util

--- a/p4_symbolic/util/io.h
+++ b/p4_symbolic/util/io.h
@@ -24,13 +24,13 @@
 
 #include <string>
 
-#include "absl/status/status.h"
+#include "p4_pdpi/utils/status_utils.h"
 
 namespace p4_symbolic {
 namespace util {
 
 // Read the entire content of the file and store it in "output".
-absl::Status ReadFile(std::string path, std::string *output);
+pdpi::StatusOr<std::string> ReadFile(std::string path);
 
 }  // namespace util
 }  // namespace p4_symbolic

--- a/p4_symbolic/util/io.h
+++ b/p4_symbolic/util/io.h
@@ -1,0 +1,38 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a test file for our protobuf specifications of bmv2 json.
+// It reads an input bmv2 json string (usually the output of p4c) via stdin,
+// it parses the string using protobuf, and then dumps the parsed protobuf
+// objects using protobuf text format and json.
+// The dumps are written to output files whose paths are provided as command
+// line arguments.
+
+#ifndef P4_SYMBOLIC_UTIL_IO_H_
+#define P4_SYMBOLIC_UTIL_IO_H_
+
+#include <string>
+
+#include "absl/status/status.h"
+
+namespace p4_symbolic {
+namespace util {
+
+// Read the entire content of the file and store it in "output".
+absl::Status ReadFile(std::string path, std::string *output);
+
+}  // namespace util
+}  // namespace p4_symbolic
+
+#endif  // P4_SYMBOLIC_UTIL_IO_H_

--- a/p4_symbolic/util/status.cc
+++ b/p4_symbolic/util/status.cc
@@ -26,7 +26,7 @@ namespace util {
 
 namespace pb_err = google::protobuf::util::error;
 
-absl::Status protobuf_to_absl_status(
+absl::Status ProtobufToAbslStatus(
     const google::protobuf::util::Status& status) {
   absl::StatusCode out_code;
 

--- a/p4_symbolic/util/status.cc
+++ b/p4_symbolic/util/status.cc
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This is a test file for our protobuf specifications of bmv2 json.
-// It reads an input bmv2 json string (usually the output of p4c) via stdin,
-// it parses the string using protobuf, and then dumps the parsed protobuf
-// objects using protobuf text format and json.
-// The dumps are written to output files whose paths are provided as command
-// line arguments.
-
 #include "p4_symbolic/util/status.h"
 
 namespace p4_symbolic {

--- a/p4_symbolic/util/status.cc
+++ b/p4_symbolic/util/status.cc
@@ -1,0 +1,92 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a test file for our protobuf specifications of bmv2 json.
+// It reads an input bmv2 json string (usually the output of p4c) via stdin,
+// it parses the string using protobuf, and then dumps the parsed protobuf
+// objects using protobuf text format and json.
+// The dumps are written to output files whose paths are provided as command
+// line arguments.
+
+#include "p4_symbolic/util/status.h"
+
+namespace p4_symbolic {
+namespace util {
+
+namespace pb_err = google::protobuf::util::error;
+
+absl::Status protobuf_to_absl_status(
+    const google::protobuf::util::Status& status) {
+  absl::StatusCode out_code;
+
+  google::protobuf::util::error::Code code = status.code();
+  switch (code) {
+    case pb_err::OK:
+      out_code = absl::StatusCode::kOk;
+      break;
+    case pb_err::CANCELLED:
+      out_code = absl::StatusCode::kCancelled;
+      break;
+    case pb_err::UNKNOWN:
+      out_code = absl::StatusCode::kUnknown;
+      break;
+    case pb_err::INVALID_ARGUMENT:
+      out_code = absl::StatusCode::kInvalidArgument;
+      break;
+    case pb_err::DEADLINE_EXCEEDED:
+      out_code = absl::StatusCode::kDeadlineExceeded;
+      break;
+    case pb_err::NOT_FOUND:
+      out_code = absl::StatusCode::kNotFound;
+      break;
+    case pb_err::ALREADY_EXISTS:
+      out_code = absl::StatusCode::kAlreadyExists;
+      break;
+    case pb_err::PERMISSION_DENIED:
+      out_code = absl::StatusCode::kPermissionDenied;
+      break;
+    case pb_err::UNAUTHENTICATED:
+      out_code = absl::StatusCode::kUnauthenticated;
+      break;
+    case pb_err::RESOURCE_EXHAUSTED:
+      out_code = absl::StatusCode::kResourceExhausted;
+      break;
+    case pb_err::FAILED_PRECONDITION:
+      out_code = absl::StatusCode::kFailedPrecondition;
+      break;
+    case pb_err::ABORTED:
+      out_code = absl::StatusCode::kAborted;
+      break;
+    case pb_err::OUT_OF_RANGE:
+      out_code = absl::StatusCode::kOutOfRange;
+      break;
+    case pb_err::UNIMPLEMENTED:
+      out_code = absl::StatusCode::kUnimplemented;
+      break;
+    case pb_err::INTERNAL:
+      out_code = absl::StatusCode::kInternal;
+      break;
+    case pb_err::UNAVAILABLE:
+      out_code = absl::StatusCode::kUnavailable;
+      break;
+    case pb_err::DATA_LOSS:
+      out_code = absl::StatusCode::kDataLoss;
+      break;
+  }
+
+  return absl::Status(out_code, status.error_message().ToString());
+}
+
+}  // namespace util
+}  // namespace p4_symbolic

--- a/p4_symbolic/util/status.h
+++ b/p4_symbolic/util/status.h
@@ -1,0 +1,38 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a test file for our protobuf specifications of bmv2 json.
+// It reads an input bmv2 json string (usually the output of p4c) via stdin,
+// it parses the string using protobuf, and then dumps the parsed protobuf
+// objects using protobuf text format and json.
+// The dumps are written to output files whose paths are provided as command
+// line arguments.
+
+#ifndef P4_SYMBOLIC_UTIL_STATUS_H_
+#define P4_SYMBOLIC_UTIL_STATUS_H_
+
+#include "absl/status/status.h"
+#include "google/protobuf/stubs/status.h"
+
+namespace p4_symbolic {
+namespace util {
+
+// Transform protobuf status into semantically equivalent absl status.
+absl::Status protobuf_to_absl_status(
+    const google::protobuf::util::Status& status);
+
+}  // namespace util
+}  // namespace p4_symbolic
+
+#endif  // P4_SYMBOLIC_UTIL_STATUS_H_

--- a/p4_symbolic/util/status.h
+++ b/p4_symbolic/util/status.h
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This is a test file for our protobuf specifications of bmv2 json.
-// It reads an input bmv2 json string (usually the output of p4c) via stdin,
-// it parses the string using protobuf, and then dumps the parsed protobuf
-// objects using protobuf text format and json.
-// The dumps are written to output files whose paths are provided as command
-// line arguments.
-
 #ifndef P4_SYMBOLIC_UTIL_STATUS_H_
 #define P4_SYMBOLIC_UTIL_STATUS_H_
 

--- a/p4_symbolic/util/status.h
+++ b/p4_symbolic/util/status.h
@@ -28,7 +28,7 @@
 namespace p4_symbolic {
 namespace util {
 
-// Transform protobuf status into semantically equivalent absl status.
+// Transforms protobuf status into semantically equivalent absl status.
 absl::Status ProtobufToAbslStatus(const google::protobuf::util::Status& status);
 
 }  // namespace util

--- a/p4_symbolic/util/status.h
+++ b/p4_symbolic/util/status.h
@@ -29,8 +29,7 @@ namespace p4_symbolic {
 namespace util {
 
 // Transform protobuf status into semantically equivalent absl status.
-absl::Status protobuf_to_absl_status(
-    const google::protobuf::util::Status& status);
+absl::Status ProtobufToAbslStatus(const google::protobuf::util::Status& status);
 
 }  // namespace util
 }  // namespace p4_symbolic


### PR DESCRIPTION
* Add util files for file I/O and absl::Status handling
* Remove duplicate Bazel dependency
* Modify p4-samples commands to output p4info in protobuf format instead of JSON