### PR TITLE
Parsing Pipeline: Add a wrapper around PDPI::P4InfoManager (2/4)

### DIFF
--- a/p4_symbolic/ir/BUILD.bazel
+++ b/p4_symbolic/ir/BUILD.bazel
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
+# Protobuf library rules.
 cc_proto_library(
     name = "ir_cc_proto",
     visibility = ["//p4_symbolic:__subpackages__"],
@@ -27,5 +28,21 @@ proto_library(
     deps = [
         "//p4_symbolic/bmv2:bmv2_proto",
         "@p4_pdpi//p4_pdpi:ir_proto",
+    ],
+)
+
+## CC library rules.
+cc_library(
+    name = "pdpi_driver",
+    srcs = [
+        "pdpi_driver.cc",
+    ],
+    hdrs = [
+        "pdpi_driver.h",
+    ],
+    visibility = ["//p4_symbolic:__subpackages__"],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@p4_pdpi//p4_pdpi:pdpi",
     ],
 )

--- a/p4_symbolic/ir/BUILD.bazel
+++ b/p4_symbolic/ir/BUILD.bazel
@@ -44,5 +44,6 @@ cc_library(
     deps = [
         "@com_google_absl//absl/status",
         "@p4_pdpi//p4_pdpi:pdpi",
+        "@p4_pdpi//p4_pdpi/utils:status_utils",
     ],
 )

--- a/p4_symbolic/ir/BUILD.bazel
+++ b/p4_symbolic/ir/BUILD.bazel
@@ -15,7 +15,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
-# Protobuf library rules.
 cc_proto_library(
     name = "ir_cc_proto",
     visibility = ["//p4_symbolic:__subpackages__"],
@@ -31,7 +30,6 @@ proto_library(
     ],
 )
 
-## CC library rules.
 cc_library(
     name = "pdpi_driver",
     srcs = [

--- a/p4_symbolic/ir/pdpi_driver.cc
+++ b/p4_symbolic/ir/pdpi_driver.cc
@@ -33,9 +33,6 @@ namespace ir {
 // Parse into standard p4 protobuf and then into PDPI.
 // If either of these steps fail, their failure status is returned.
 pdpi::StatusOr<pdpi::ir::IrP4Info> ParsePdpi(std::string p4info_path) {
-  // Verify link and compile versions are the same.
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
   // Parse the p4info file into the standard p4 protobuf.
   p4::config::v1::P4Info p4info;
   RETURN_IF_ERROR(pdpi::ReadProtoFromFile(p4info_path, &p4info));

--- a/p4_symbolic/ir/pdpi_driver.cc
+++ b/p4_symbolic/ir/pdpi_driver.cc
@@ -30,20 +30,14 @@
 namespace p4_symbolic {
 namespace ir {
 
-// Parse into standard p4 protobuf and then into PDPI.
-// If either of these steps fail, their failure status is returned.
-pdpi::StatusOr<pdpi::ir::IrP4Info> ParsePdpi(std::string p4info_path) {
-  // Parse the p4info file into the standard p4 protobuf.
+pdpi::StatusOr<pdpi::ir::IrP4Info> ParseP4InfoFile(std::string p4info_path) {
   p4::config::v1::P4Info p4info;
   RETURN_IF_ERROR(pdpi::ReadProtoFromFile(p4info_path, &p4info));
 
-  // Transform the p4 protobuf to a pdpi protobuf using a pdpi::P4InfoManager.
-  pdpi::StatusOr<std::unique_ptr<pdpi::P4InfoManager>> status_or_info =
-      pdpi::P4InfoManager::Create(p4info);
-  RETURN_IF_ERROR(status_or_info.status());
+  ASSIGN_OR_RETURN(std::unique_ptr<pdpi::P4InfoManager> & info_manager,
+                   pdpi::P4InfoManager::Create(p4info));
 
-  return pdpi::StatusOr<pdpi::ir::IrP4Info>(
-      status_or_info.value()->GetIrP4Info());
+  return info_manager->GetIrP4Info();
 }
 
 }  // namespace ir

--- a/p4_symbolic/ir/pdpi_driver.cc
+++ b/p4_symbolic/ir/pdpi_driver.cc
@@ -12,15 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This is a test file for our protobuf specifications of bmv2 json.
-// It reads an input bmv2 json string (usually the output of p4c) via stdin,
-// it parses the string using protobuf, and then dumps the parsed protobuf
-// objects using protobuf text format and json.
-// The dumps are written to output files whose paths are provided as command
-// line arguments.
-
-// The implementation of our PDPI interface.
-
 #include "p4_symbolic/ir/pdpi_driver.h"
 
 #include <memory>

--- a/p4_symbolic/ir/pdpi_driver.cc
+++ b/p4_symbolic/ir/pdpi_driver.cc
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a test file for our protobuf specifications of bmv2 json.
+// It reads an input bmv2 json string (usually the output of p4c) via stdin,
+// it parses the string using protobuf, and then dumps the parsed protobuf
+// objects using protobuf text format and json.
+// The dumps are written to output files whose paths are provided as command
+// line arguments.
+
+// The implementation of our PDPI interface.
+
+#include "p4_symbolic/ir/pdpi_driver.h"
+
+#include <memory>
+
+#include "p4_pdpi/util.h"
+
+namespace p4_symbolic {
+namespace ir {
+
+// Parse into standard p4 protobuf and then into PDPI.
+// If either of these steps fail, their failure status is returned.
+absl::Status parse_pdpi(std::string p4info_path, pdpi::ir::IrP4Info *output) {
+  // Verify link and compile versions are the same.
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  // Parse the p4info file into the standard p4 protobuf.
+  p4::config::v1::P4Info p4info;
+  absl::Status status = pdpi::ReadProtoFromFile(p4info_path, &p4info);
+  if (!status.ok()) {
+    return status;
+  }
+
+  // Transform the p4 protobuf to a pdpi protobuf using a pdpi::P4InfoManager.
+  pdpi::StatusOr<std::unique_ptr<pdpi::P4InfoManager>> status_or_info =
+      pdpi::P4InfoManager::Create(p4info);
+  if (!status_or_info.ok()) {
+    return status_or_info.status();
+  }
+
+  *output = status_or_info.value()->GetIrP4Info();
+  return absl::OkStatus();
+}
+
+}  // namespace ir
+}  // namespace p4_symbolic

--- a/p4_symbolic/ir/pdpi_driver.h
+++ b/p4_symbolic/ir/pdpi_driver.h
@@ -12,16 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This is a test file for our protobuf specifications of bmv2 json.
-// It reads an input bmv2 json string (usually the output of p4c) via stdin,
-// it parses the string using protobuf, and then dumps the parsed protobuf
-// objects using protobuf text format and json.
-// The dumps are written to output files whose paths are provided as command
-// line arguments.
-
-// Defines the signature of the driver function exposing
-// PDPI structure as a blackbox.
-
 #ifndef P4_SYMBOLIC_IR_PDPI_DRIVER_H_
 #define P4_SYMBOLIC_IR_PDPI_DRIVER_H_
 

--- a/p4_symbolic/ir/pdpi_driver.h
+++ b/p4_symbolic/ir/pdpi_driver.h
@@ -1,0 +1,45 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a test file for our protobuf specifications of bmv2 json.
+// It reads an input bmv2 json string (usually the output of p4c) via stdin,
+// it parses the string using protobuf, and then dumps the parsed protobuf
+// objects using protobuf text format and json.
+// The dumps are written to output files whose paths are provided as command
+// line arguments.
+
+// Defines the signature of the driver function exposing
+// PDPI structure as a blackbox.
+
+#ifndef P4_SYMBOLIC_IR_PDPI_DRIVER_H_
+#define P4_SYMBOLIC_IR_PDPI_DRIVER_H_
+
+#include <string>
+
+#include "absl/status/status.h"
+#include "p4_pdpi/ir.h"
+
+namespace p4_symbolic {
+namespace ir {
+
+// Parse the p4info file given by "p4info_path" into a pdpi:IrP4Info
+// instance, placing the output in "output".
+// Returns ok if successful, or an appropriate failure status in case of
+// a badly formatted input file, or if the file does not exist.
+absl::Status parse_pdpi(std::string p4info_path, pdpi::ir::IrP4Info *output);
+
+}  // namespace ir
+}  // namespace p4_symbolic
+
+#endif  // P4_SYMBOLIC_IR_PDPI_DRIVER_H_

--- a/p4_symbolic/ir/pdpi_driver.h
+++ b/p4_symbolic/ir/pdpi_driver.h
@@ -34,11 +34,11 @@
 namespace p4_symbolic {
 namespace ir {
 
-// Parse the p4info file given by "p4info_path" into a pdpi:IrP4Info
+// Parses the p4info file given by "p4info_path" into a pdpi:IrP4Info
 // instance.
-// Return the parsed IrP4Info instance, or an appropriate failure status
+// Returns the parsed IrP4Info instance, or an appropriate failure status
 // in case of a badly formatted input file, or if the file does not exist.
-pdpi::StatusOr<pdpi::ir::IrP4Info> ParsePdpi(std::string p4info_path);
+pdpi::StatusOr<pdpi::ir::IrP4Info> ParseP4InfoFile(std::string p4info_path);
 
 }  // namespace ir
 }  // namespace p4_symbolic

--- a/p4_symbolic/ir/pdpi_driver.h
+++ b/p4_symbolic/ir/pdpi_driver.h
@@ -29,6 +29,7 @@
 
 #include "absl/status/status.h"
 #include "p4_pdpi/ir.h"
+#include "p4_pdpi/utils/status_utils.h"
 
 namespace p4_symbolic {
 namespace ir {
@@ -37,7 +38,7 @@ namespace ir {
 // instance, placing the output in "output".
 // Returns ok if successful, or an appropriate failure status in case of
 // a badly formatted input file, or if the file does not exist.
-absl::Status parse_pdpi(std::string p4info_path, pdpi::ir::IrP4Info *output);
+pdpi::StatusOr<pdpi::ir::IrP4Info> ParsePdpi(std::string p4info_path);
 
 }  // namespace ir
 }  // namespace p4_symbolic

--- a/p4_symbolic/ir/pdpi_driver.h
+++ b/p4_symbolic/ir/pdpi_driver.h
@@ -35,9 +35,9 @@ namespace p4_symbolic {
 namespace ir {
 
 // Parse the p4info file given by "p4info_path" into a pdpi:IrP4Info
-// instance, placing the output in "output".
-// Returns ok if successful, or an appropriate failure status in case of
-// a badly formatted input file, or if the file does not exist.
+// instance.
+// Return the parsed IrP4Info instance, or an appropriate failure status
+// in case of a badly formatted input file, or if the file does not exist.
 pdpi::StatusOr<pdpi::ir::IrP4Info> ParsePdpi(std::string p4info_path);
 
 }  // namespace ir


### PR DESCRIPTION
Wrapper handles reading input p4info protobuf and transforming it to a pdpi:IrP4Info instance.