### PR TITLE
Parsing Pipeline: Add wrapper for parsing JSON file into our bmv2 protobuf (3/4)

### DIFF
--- a/p4_symbolic/bmv2/BUILD.bazel
+++ b/p4_symbolic/bmv2/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_proto_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//p4_symbolic/bmv2:test.bzl", "bmv2_protobuf_parsing_test")
 
@@ -31,6 +31,23 @@ proto_library(
     visibility = ["//p4_symbolic:__subpackages__"],
     deps = [
         "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+## CC library rules.
+cc_library(
+    name = "bmv2",
+    srcs = [
+        "bmv2.cc",
+    ],
+    hdrs = [
+        "bmv2.h",
+    ],
+    visibility = ["//p4_symbolic:__subpackages__"],
+    deps = [
+        ":bmv2_cc_proto",
+        "//p4_symbolic/util",
+        "@com_google_absl//absl/status",
     ],
 )
 

--- a/p4_symbolic/bmv2/BUILD.bazel
+++ b/p4_symbolic/bmv2/BUILD.bazel
@@ -16,7 +16,6 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//p4_symbolic/bmv2:test.bzl", "bmv2_protobuf_parsing_test")
 
-# Rules for building protobuf.
 cc_proto_library(
     name = "bmv2_cc_proto",
     visibility = ["//p4_symbolic:__subpackages__"],
@@ -34,7 +33,6 @@ proto_library(
     ],
 )
 
-## CC library rules.
 cc_library(
     name = "bmv2",
     srcs = [
@@ -51,7 +49,6 @@ cc_library(
     ],
 )
 
-# Rules for building test.cc binary.
 cc_binary(
     name = "test",
     srcs = ["test.cc"],

--- a/p4_symbolic/bmv2/BUILD.bazel
+++ b/p4_symbolic/bmv2/BUILD.bazel
@@ -47,7 +47,7 @@ cc_library(
     deps = [
         ":bmv2_cc_proto",
         "//p4_symbolic/util",
-        "@com_google_absl//absl/status",
+        "@p4_pdpi//p4_pdpi/utils:status_utils",
     ],
 )
 

--- a/p4_symbolic/bmv2/BUILD.bazel
+++ b/p4_symbolic/bmv2/BUILD.bazel
@@ -55,7 +55,10 @@ cc_library(
 cc_binary(
     name = "test",
     srcs = ["test.cc"],
-    deps = [":bmv2_cc_proto"],
+    deps = [
+        ":bmv2",
+        ":bmv2_cc_proto",
+    ],
 )
 
 # Test rules: one per program in //p4-samples

--- a/p4_symbolic/bmv2/bmv2.cc
+++ b/p4_symbolic/bmv2/bmv2.cc
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This is a test file for our protobuf specifications of bmv2 json.
-// It reads an input bmv2 json string (usually the output of p4c) via stdin,
-// it parses the string using protobuf, and then dumps the parsed protobuf
-// objects using protobuf text format and json.
-// The dumps are written to output files whose paths are provided as command
-// line arguments.
-
 #include "p4_symbolic/bmv2/bmv2.h"
 
 #include "google/protobuf/util/json_util.h"
@@ -28,24 +21,18 @@
 namespace p4_symbolic {
 namespace bmv2 {
 
-// Parse the content of the given file using
-// google::protobuf::util::JsonStringToMessage.
-// If that call fails, its failure status is returned.
-pdpi::StatusOr<P4Program> ParseBmv2Json(std::string json_path) {
-  // Read input json from file.
-  pdpi::StatusOr<std::string> read_status = util::ReadFile(json_path);
-  RETURN_IF_ERROR(read_status.status());
+pdpi::StatusOr<P4Program> ParseBmv2JsonFile(std::string json_path) {
+  ASSIGN_OR_RETURN(std::string file_content, util::ReadFile(json_path));
 
-  // Parsing JSON with protobuf.
   P4Program output;
   google::protobuf::util::JsonParseOptions options;
   options.ignore_unknown_fields = true;
   google::protobuf::util::Status parse_status =
-      google::protobuf::util::JsonStringToMessage(read_status.value(), &output,
+      google::protobuf::util::JsonStringToMessage(file_content, &output,
                                                   options);
   RETURN_IF_ERROR(util::ProtobufToAbslStatus(parse_status));
 
-  return pdpi::StatusOr<P4Program>(output);
+  return output;
 }
 
 }  // namespace bmv2

--- a/p4_symbolic/bmv2/bmv2.cc
+++ b/p4_symbolic/bmv2/bmv2.cc
@@ -1,0 +1,59 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a test file for our protobuf specifications of bmv2 json.
+// It reads an input bmv2 json string (usually the output of p4c) via stdin,
+// it parses the string using protobuf, and then dumps the parsed protobuf
+// objects using protobuf text format and json.
+// The dumps are written to output files whose paths are provided as command
+// line arguments.
+
+#include "p4_symbolic/bmv2/bmv2.h"
+
+#include "google/protobuf/util/json_util.h"
+#include "p4_symbolic/util/io.h"
+#include "p4_symbolic/util/status.h"
+
+namespace p4_symbolic {
+namespace bmv2 {
+
+// Parse the content of the given file using
+// google::protobuf::util::JsonStringToMessage.
+// If that call fails, its failure status is returned.
+absl::Status parse_bmv2_json(std::string json_path, P4Program *output) {
+  // Verify link and compile versions are the same.
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  // Read input json from file.
+  std::string input;
+  absl::Status read_status = p4_symbolic::util::ReadFile(json_path, &input);
+  if (!read_status.ok()) {
+    return read_status;
+  }
+
+  // Parsing JSON with protobuf.
+  google::protobuf::util::JsonParseOptions options;
+  options.ignore_unknown_fields = true;
+  google::protobuf::util::Status parse_status =
+      google::protobuf::util::JsonStringToMessage(input, output, options);
+
+  if (!parse_status.ok()) {
+    return p4_symbolic::util::protobuf_to_absl_status(parse_status);
+  }
+
+  return absl::OkStatus();
+}
+
+}  // namespace bmv2
+}  // namespace p4_symbolic

--- a/p4_symbolic/bmv2/bmv2.h
+++ b/p4_symbolic/bmv2/bmv2.h
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a test file for our protobuf specifications of bmv2 json.
+// It reads an input bmv2 json string (usually the output of p4c) via stdin,
+// it parses the string using protobuf, and then dumps the parsed protobuf
+// objects using protobuf text format and json.
+// The dumps are written to output files whose paths are provided as command
+// line arguments.
+
+#ifndef P4_SYMBOLIC_BMV2_BMV2_H_
+#define P4_SYMBOLIC_BMV2_BMV2_H_
+
+#include <string>
+
+#include "absl/status/status.h"
+#include "p4_symbolic/bmv2/bmv2.pb.h"
+
+namespace p4_symbolic {
+namespace bmv2 {
+
+// Read and parse the bmv2 JSON content (typically the output of p4c) from
+// the given file, and put the parsed result in "output".
+// Returns ok if successful, or an appropriate failure status in case
+// of a badly formatted input file, or if the file does not exist.
+absl::Status parse_bmv2_json(std::string json_path, P4Program *output);
+
+}  // namespace bmv2
+}  // namespace p4_symbolic
+
+#endif  // P4_SYMBOLIC_BMV2_BMV2_H_

--- a/p4_symbolic/bmv2/bmv2.h
+++ b/p4_symbolic/bmv2/bmv2.h
@@ -24,7 +24,7 @@
 
 #include <string>
 
-#include "absl/status/status.h"
+#include "p4_pdpi/utils/status_utils.h"
 #include "p4_symbolic/bmv2/bmv2.pb.h"
 
 namespace p4_symbolic {
@@ -34,7 +34,7 @@ namespace bmv2 {
 // the given file, and put the parsed result in "output".
 // Returns ok if successful, or an appropriate failure status in case
 // of a badly formatted input file, or if the file does not exist.
-absl::Status parse_bmv2_json(std::string json_path, P4Program *output);
+pdpi::StatusOr<P4Program> ParseBmv2Json(std::string json_path);
 
 }  // namespace bmv2
 }  // namespace p4_symbolic

--- a/p4_symbolic/bmv2/bmv2.h
+++ b/p4_symbolic/bmv2/bmv2.h
@@ -12,13 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This is a test file for our protobuf specifications of bmv2 json.
-// It reads an input bmv2 json string (usually the output of p4c) via stdin,
-// it parses the string using protobuf, and then dumps the parsed protobuf
-// objects using protobuf text format and json.
-// The dumps are written to output files whose paths are provided as command
-// line arguments.
-
 #ifndef P4_SYMBOLIC_BMV2_BMV2_H_
 #define P4_SYMBOLIC_BMV2_BMV2_H_
 
@@ -30,12 +23,12 @@
 namespace p4_symbolic {
 namespace bmv2 {
 
-// Read and parse the bmv2 JSON content (typically the output of p4c) from
+// Reads and parses the bmv2 JSON content (typically the output of p4c) from
 // the given file.
 // Returns the resulting P4Program instance if successful, or an appropriate
 // failure status in case of a badly formatted input file, or if the file
 // does not exist.
-pdpi::StatusOr<P4Program> ParseBmv2Json(std::string json_path);
+pdpi::StatusOr<P4Program> ParseBmv2JsonFile(std::string json_path);
 
 }  // namespace bmv2
 }  // namespace p4_symbolic

--- a/p4_symbolic/bmv2/bmv2.h
+++ b/p4_symbolic/bmv2/bmv2.h
@@ -31,9 +31,10 @@ namespace p4_symbolic {
 namespace bmv2 {
 
 // Read and parse the bmv2 JSON content (typically the output of p4c) from
-// the given file, and put the parsed result in "output".
-// Returns ok if successful, or an appropriate failure status in case
-// of a badly formatted input file, or if the file does not exist.
+// the given file.
+// Returns the resulting P4Program instance if successful, or an appropriate
+// failure status in case of a badly formatted input file, or if the file
+// does not exist.
 pdpi::StatusOr<P4Program> ParseBmv2Json(std::string json_path);
 
 }  // namespace bmv2

--- a/p4_symbolic/bmv2/test.bzl
+++ b/p4_symbolic/bmv2/test.bzl
@@ -210,7 +210,7 @@ def bmv2_protobuf_parsing_test(name, p4_program, golden_file, p4_deps = []):
         outs = [proto_filename, json_filename],
         tools = ["//p4_symbolic/bmv2:test"],
         cmd = """
-            $(location //p4_symbolic/bmv2:test) $(OUTS) < $(SRCS)
+            $(location //p4_symbolic/bmv2:test) $(SRCS) $(OUTS)
             """,
     )
 

--- a/p4_symbolic/bmv2/test.cc
+++ b/p4_symbolic/bmv2/test.cc
@@ -54,16 +54,17 @@ int main(int argc, char* argv[]) {
 
   // Parse JSON using bmv2.cc.
   std::string input(argv[1]);
-  p4_symbolic::bmv2::P4Program p4_buf;
-  absl::Status status = p4_symbolic::bmv2::parse_bmv2_json(input, &p4_buf);
+  pdpi::StatusOr<p4_symbolic::bmv2::P4Program> status =
+      p4_symbolic::bmv2::ParseBmv2Json(input);
   if (!status.ok()) {
-    std::cerr << "Error reading input file: " << status << std::endl;
+    std::cerr << "Error reading input file: " << status.status() << std::endl;
     return 1;
   }
 
   // Dumping protobuf.
   std::string protobuf_output_str;
-  google::protobuf::TextFormat::PrintToString(p4_buf, &protobuf_output_str);
+  google::protobuf::TextFormat::PrintToString(status.value(),
+                                              &protobuf_output_str);
   WriteFile(argv[2], protobuf_output_str);
 
   // Dumping JSON.
@@ -73,7 +74,7 @@ int main(int argc, char* argv[]) {
   dumping_options.preserve_proto_field_names = true;
 
   std::string json_output_str;
-  google::protobuf::util::MessageToJsonString(p4_buf, &json_output_str,
+  google::protobuf::util::MessageToJsonString(status.value(), &json_output_str,
                                               dumping_options);
   WriteFile(argv[3], json_output_str);
 

--- a/p4_symbolic/bmv2/test.cc
+++ b/p4_symbolic/bmv2/test.cc
@@ -36,10 +36,10 @@ void WriteFile(char path[], const std::string& content) {
 }
 
 // The main test routine for parsing bmv2 json with protobuf.
-// Parses bmv2 json that is fed in through stdin and dumps
-// the resulting native protobuf and json data to files.
-// Expects the paths of the protobuf output file and json
-// output file to be passed as command line arguments respectively.
+// Parses bmv2 json file and dumps the resulting bmv2 protobuf
+// and json data to files.
+// Expects the paths of the input json file and the protobuf and json output
+// files to be passed as command line arguments in order.
 int main(int argc, char* argv[]) {
   // Verify link and compile versions are the same.
   GOOGLE_PROTOBUF_VERIFY_VERSION;

--- a/p4_symbolic/bmv2/test.cc
+++ b/p4_symbolic/bmv2/test.cc
@@ -46,24 +46,25 @@ int main(int argc, char* argv[]) {
 
   // Validate command line arguments.
   if (argc != 4) {
-    std::cout << "Usage: ./main <input JSON file> <protobuf output file> <json "
-                 "output file>."
+    std::cout << "Usage: " << argv[0]
+              << " <input JSON file> <protobuf output file> <json output file>."
               << std::endl;
     return 0;
   }
 
   // Parse JSON using bmv2.cc.
-  std::string input(argv[1]);
-  pdpi::StatusOr<p4_symbolic::bmv2::P4Program> status =
-      p4_symbolic::bmv2::ParseBmv2Json(input);
-  if (!status.ok()) {
-    std::cerr << "Error reading input file: " << status.status() << std::endl;
+  const std::string input(argv[1]);
+  pdpi::StatusOr<p4_symbolic::bmv2::P4Program> bmv2_or_status =
+      p4_symbolic::bmv2::ParseBmv2JsonFile(input);
+  if (!bmv2_or_status.ok()) {
+    std::cerr << "Error reading input file: " << bmv2_or_status.status()
+              << std::endl;
     return 1;
   }
 
   // Dumping protobuf.
   std::string protobuf_output_str;
-  google::protobuf::TextFormat::PrintToString(status.value(),
+  google::protobuf::TextFormat::PrintToString(bmv2_or_status.value(),
                                               &protobuf_output_str);
   WriteFile(argv[2], protobuf_output_str);
 
@@ -74,8 +75,8 @@ int main(int argc, char* argv[]) {
   dumping_options.preserve_proto_field_names = true;
 
   std::string json_output_str;
-  google::protobuf::util::MessageToJsonString(status.value(), &json_output_str,
-                                              dumping_options);
+  google::protobuf::util::MessageToJsonString(
+      bmv2_or_status.value(), &json_output_str, dumping_options);
   WriteFile(argv[3], json_output_str);
 
   // Clean up.

--- a/p4_symbolic/bmv2/test.cc
+++ b/p4_symbolic/bmv2/test.cc
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 // This is a test file for our protobuf specifications of bmv2 json.
-// It reads an input bmv2 json string (usually the output of p4c) via stdin,
-// it parses the string using protobuf, and then dumps the parsed protobuf
+// It reads an input bmv2 json file (usually the output of p4c) specified
+// as a command line argument.
+// It parses that file using protobuf, and then dumps the parsed protobuf
 // objects using protobuf text format and json.
 // The dumps are written to output files whose paths are provided as command
 // line arguments.
@@ -63,10 +64,7 @@ int main(int argc, char* argv[]) {
   }
 
   // Dumping protobuf.
-  std::string protobuf_output_str;
-  google::protobuf::TextFormat::PrintToString(bmv2_or_status.value(),
-                                              &protobuf_output_str);
-  WriteFile(argv[2], protobuf_output_str);
+  WriteFile(argv[2], bmv2_or_status.value().DebugString());
 
   // Dumping JSON.
   google::protobuf::util::JsonPrintOptions dumping_options;


### PR DESCRIPTION
Update bmv2 protobuf test to use (and thus test) the wrapper.