### PR TITLE
Header files for the solver structure

### DIFF
--- a/p4_symbolic/symbolic/action.h
+++ b/p4_symbolic/symbolic/action.h
@@ -40,8 +40,8 @@ pdpi::StatusOr<IntermediateState> EvaluateAction(
     const ir::Action &action, const std::vector<z3::expr> &symbolic_parameters,
     const IntermediateState &state);
 
-// Internal functions used to Evaluate statements and expressions within an action
-// body. These are internal functions not used beyond this header and its
+// Internal functions used to Evaluate statements and expressions within an
+// action body. These are internal functions not used beyond this header and its
 // associated source file.
 
 // The scope of this action: maps local variable names to their symbolic values.
@@ -49,9 +49,9 @@ using ActionContext = std::unordered_map<std::string, z3::expr>;
 
 // Performs a switch case over support statement types and call the
 // appropriate function.
-pdpi::StatusOr<IntermediateState> EvaluateStatement(const ir::Statement &statement,
-                                           const IntermediateState &state,
-                                           ActionContext *context);
+pdpi::StatusOr<IntermediateState> EvaluateStatement(
+    const ir::Statement &statement, const IntermediateState &state,
+    ActionContext *context);
 
 // Constructs a symbolic expression for the assignment value, and either
 // constrains it in an enclosing assignment expression, or stores it in
@@ -63,18 +63,18 @@ pdpi::StatusOr<IntermediateState> EvaluateAssignmentStatement(
 // Constructs a symbolic expression corresponding to this value, according
 // to its type.
 pdpi::StatusOr<z3::expr> EvaluateRValue(const ir::RValue &rvalue,
-                                   const IntermediateState &state,
-                                   ActionContext *context);
+                                        const IntermediateState &state,
+                                        ActionContext *context);
 
 // Extract the field symbolic value from the symbolic state.
 pdpi::StatusOr<z3::expr> EvaluateFieldValue(const ir::FieldValue &field_value,
-                                       const IntermediateState &state,
-                                       ActionContext *context);
+                                            const IntermediateState &state,
+                                            ActionContext *context);
 
 // Looks up the symbolic value of the variable in the action scope.
 pdpi::StatusOr<z3::expr> EvaluateVariable(const ir::Variable &variable,
-                                     const IntermediateState &state,
-                                     ActionContext *context);
+                                          const IntermediateState &state,
+                                          ActionContext *context);
 
 }  // namespace action
 }  // namespace symbolic

--- a/p4_symbolic/symbolic/action.h
+++ b/p4_symbolic/symbolic/action.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Contains functions used to symbolically analyze/interprate actions
-// and their bodies.
+// Contains functions used to symbolically evaluate actions and their bodies.
 // An action is represented as a boolean symbolic z3 expression over
 // unconstrained symbolic parameters corresponding to its actual P4 parameters.
 
@@ -33,48 +32,48 @@ namespace p4_symbolic {
 namespace symbolic {
 namespace action {
 
-// Symbolically runs the given action on the given symbolic parameters.
+// Symbolically evaluates the given action on the given symbolic parameters.
 // This produces a symbolic expression on the symbolic parameters that is
 // semantically equivalent to the behavior of the action on its concrete
 // parameters.
-pdpi::StatusOr<SymbolicState> RunAction(
+pdpi::StatusOr<IntermediateState> EvaluateAction(
     const ir::Action &action, const std::vector<z3::expr> &symbolic_parameters,
-    const SymbolicState &state);
+    const IntermediateState &state);
 
-// Internal functions used to run statements and expressions within an action
+// Internal functions used to Evaluate statements and expressions within an action
 // body. These are internal functions not used beyond this header and its
 // associated source file.
 
-// The scope of this action: maps variable names to their symbolic values.
+// The scope of this action: maps local variable names to their symbolic values.
 using ActionContext = std::unordered_map<std::string, z3::expr>;
 
 // Performs a switch case over support statement types and call the
 // appropriate function.
-pdpi::StatusOr<SymbolicState> RunStatement(const ir::Statement &statement,
-                                           const SymbolicState &state,
+pdpi::StatusOr<IntermediateState> EvaluateStatement(const ir::Statement &statement,
+                                           const IntermediateState &state,
                                            ActionContext *context);
 
 // Constructs a symbolic expression for the assignment value, and either
 // constrains it in an enclosing assignment expression, or stores it in
 // the action scope.
-pdpi::StatusOr<SymbolicState> RunAssignmentStatement(
-    const ir::AssignmentStatement &assignment, const SymbolicState &state,
+pdpi::StatusOr<IntermediateState> EvaluateAssignmentStatement(
+    const ir::AssignmentStatement &assignment, const IntermediateState &state,
     ActionContext *context);
 
 // Constructs a symbolic expression corresponding to this value, according
 // to its type.
-pdpi::StatusOr<z3::expr> RunRValue(const ir::RValue &rvalue,
-                                   const SymbolicState &state,
+pdpi::StatusOr<z3::expr> EvaluateRValue(const ir::RValue &rvalue,
+                                   const IntermediateState &state,
                                    ActionContext *context);
 
 // Extract the field symbolic value from the symbolic state.
-pdpi::StatusOr<z3::expr> RunFieldValue(const ir::FieldValue &field_value,
-                                       const SymbolicState &state,
+pdpi::StatusOr<z3::expr> EvaluateFieldValue(const ir::FieldValue &field_value,
+                                       const IntermediateState &state,
                                        ActionContext *context);
 
 // Looks up the symbolic value of the variable in the action scope.
-pdpi::StatusOr<z3::expr> RunVariable(const ir::Variable &variable,
-                                     const SymbolicState &state,
+pdpi::StatusOr<z3::expr> EvaluateVariable(const ir::Variable &variable,
+                                     const IntermediateState &state,
                                      ActionContext *context);
 
 }  // namespace action

--- a/p4_symbolic/symbolic/action.h
+++ b/p4_symbolic/symbolic/action.h
@@ -1,0 +1,84 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contains functions used to symbolically analyze/interprate actions
+// and their bodies.
+// An action is represented as a boolean symbolic z3 expression over
+// unconstrained symbolic parameters corresponding to its actual P4 parameters.
+
+#ifndef P4_SYMBOLIC_SYMBOLIC_ACTION_H_
+#define P4_SYMBOLIC_SYMBOLIC_ACTION_H_
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "p4_pdpi/utils/status_utils.h"
+#include "p4_symbolic/ir/ir.pb.h"
+#include "p4_symbolic/symbolic/symbolic.h"
+#include "z3++.h"
+
+namespace p4_symbolic {
+namespace symbolic {
+namespace action {
+
+// Symbolically runs the given action on the given symbolic parameters.
+// This produces a symbolic expression on the symbolic parameters that is
+// semantically equivalent to the behavior of the action on its concrete
+// parameters.
+pdpi::StatusOr<SymbolicState> RunAction(
+    const ir::Action &action, const std::vector<z3::expr> &symbolic_parameters,
+    const SymbolicState &state);
+
+// Internal functions used to run statements and expressions within an action
+// body. These are internal functions not used beyond this header and its
+// associated source file.
+
+// The scope of this action: maps variable names to their symbolic values.
+using ActionContext = std::unordered_map<std::string, z3::expr>;
+
+// Performs a switch case over support statement types and call the
+// appropriate function.
+pdpi::StatusOr<SymbolicState> RunStatement(const ir::Statement &statement,
+                                           const SymbolicState &state,
+                                           ActionContext *context);
+
+// Constructs a symbolic expression for the assignment value, and either
+// constrains it in an enclosing assignment expression, or stores it in
+// the action scope.
+pdpi::StatusOr<SymbolicState> RunAssignmentStatement(
+    const ir::AssignmentStatement &assignment, const SymbolicState &state,
+    ActionContext *context);
+
+// Constructs a symbolic expression corresponding to this value, according
+// to its type.
+pdpi::StatusOr<z3::expr> RunRValue(const ir::RValue &rvalue,
+                                   const SymbolicState &state,
+                                   ActionContext *context);
+
+// Extract the field symbolic value from the symbolic state.
+pdpi::StatusOr<z3::expr> RunFieldValue(const ir::FieldValue &field_value,
+                                       const SymbolicState &state,
+                                       ActionContext *context);
+
+// Looks up the symbolic value of the variable in the action scope.
+pdpi::StatusOr<z3::expr> RunVariable(const ir::Variable &variable,
+                                     const SymbolicState &state,
+                                     ActionContext *context);
+
+}  // namespace action
+}  // namespace symbolic
+}  // namespace p4_symbolic
+
+#endif  // P4_SYMBOLIC_SYMBOLIC_ACTION_H_

--- a/p4_symbolic/symbolic/symbolic.h
+++ b/p4_symbolic/symbolic/symbolic.h
@@ -34,10 +34,28 @@ namespace symbolic {
 // A concrete output packet within a concrete context produced by our solver
 // will be of this type.
 struct ConcreteHeader {
-  // TODO(babman): add the remaining headers and switch ints to bits.
+  // TODO(babman): Switch to bit string.
   int eth_src;
   int eth_dst;
   int eth_type;
+
+  int outer_ipv4_src;
+  int outer_ipv4_dst;
+  int outer_ipv6_dst_upper;
+  int outer_ipv6_dst_lower;
+  int outer_protocol;
+  int outer_dscp;
+  int outer_ttl;
+
+  int inner_ipv4_dst;
+  int inner_ipv6_dst_upper;
+  int inner_ipv6_dst_lower;
+  int inner_protocol;
+  int inner_dscp;
+  int inner_ttl;
+
+  int icmp_type;
+  int vid;
 };
 
 // Maps the name of a metadata field to its concrete value.
@@ -53,9 +71,29 @@ using ConcreteMetadata = std::unordered_map<std::string, int>;
 // our solver. These handles can be used to contstrain the conrete output
 // packets.
 struct SymbolicHeader {
-  z3::expr eth_src;
-  z3::expr eth_Dst;
-  z3::expr eth_type;
+  // TODO(babman): Swith to bit strings.
+  z3::expr eth_src;   // 48 bit.
+  z3::expr eth_dst;   // 48 bit.
+  z3::expr eth_type;  // 16 bit.
+
+  z3::expr outer_ipv4_src;        // 32 bit, valid if eth_type = 0x0800
+  z3::expr outer_ipv4_dst;        // 32 bit, valid if eth_type = 0x0800
+  z3::expr outer_ipv6_dst_upper;  // 64 bit, valid if eth_type = 0x86dd
+  z3::expr outer_ipv6_dst_lower;  // 64 bit, valid if eth_type = 0x86dd
+  z3::expr outer_protocol;        // 8 bit, valid if eth_type is ip
+  z3::expr outer_dscp;            // 6 bit, valid if eth_type is ip
+  z3::expr outer_ttl;             // 8 bit, valid if eth_type is ip
+
+  z3::expr inner_ipv4_dst;        // 32 bit, valid if outer_protocol = 4
+  z3::expr inner_ipv6_dst_upper;  // 64 bit, valid if outer_protocol = 4
+  z3::expr inner_ipv6_dst_lower;  // 64 bit, valid if outer_protocol = 41
+  z3::expr inner_protocol;        // 8 bit, valid if outer_protocol = 4/41
+  z3::expr inner_dscp;            // 6 bit, valid if outer_protocol = 4/41
+  z3::expr inner_ttl;             // 8 bit, valid if outer_protocol = 4/41
+
+  z3::expr icmp_type;  // 8 bit, valid if eth_type is ip
+  z3::expr vid;        // 12 bit, valid if eth_type = 0x6007
+
 };
 
 // The symbolic counterpart of ConcreteMetadata. This can be used to constrain

--- a/p4_symbolic/symbolic/symbolic.h
+++ b/p4_symbolic/symbolic/symbolic.h
@@ -1,0 +1,157 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contains the entry point to our symbolic interpretation code, as well
+// as helpers for debugging and finding concrete packets and their context.
+
+#ifndef P4_SYMBOLIC_SYMBOLIC_SYMBOLIC_H_
+#define P4_SYMBOLIC_SYMBOLIC_SYMBOLIC_H_
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "p4_pdpi/utils/status_utils.h"
+#include "p4_symbolic/ir/ir.pb.h"
+#include "z3++.h"  // TODO(babman): added as a system dependency for now.
+
+namespace p4_symbolic {
+namespace symbolic {
+
+// Specifies what a packet essentially looks like.
+// A concrete output packet within a concrete context produced by our solver
+// will be of this type.
+struct ConcreteHeader {
+  // TODO(babman): add the remaining headers and switch ints to bits.
+  int eth_src;
+  int eth_dst;
+  int eth_type;
+};
+
+// Provides symbolic handles for the fields of the symbolic packet used by
+// our solver. These handles can be used to contstrain the conrete output
+// packets.
+struct SymbolicHeader {
+  z3::expr eth_src;
+  z3::expr eth_Dst;
+  z3::expr eth_type;
+};
+
+// Expresses a concrete match for a corresponding concrete packet with a
+// table in the program.
+struct ConcreteTableMatch {
+  bool matched;  // false if no entry in this table was matched, true otherwise.
+  // if matched is false, these two fields are set to -1.
+  int entry_index;  // <concrete_state>[<table_name>] = <entry that was matched>
+  int value;
+};
+
+// Exposes a symbolic handle for every table entry being hit (by index).
+// e.g. for some table "<table_name>"
+// <symbolic_table_match>[i] = <concret_state>[<table_name>][i] was matched/hit.
+using SymbolicTableMatch = std::vector<z3::expr>;
+
+// Specifies the expected trace in the program that the corresponding
+// concrete packet is expected to take.
+struct ConcreteTrace {
+  std::unordered_map<std::string, ConcreteTableMatch> matched_entries;
+  // Can be extended more in the future to include useful
+  // flags about dropping the packet, taking specific code (e.g. if)
+  // branches, vrf, other interesting events, etc.
+};
+
+// Provides symbolic handles for the trace the symbolic packet is constrained
+// to take in the program.
+struct SymbolicTrace {
+  std::unordered_map<std::string, SymbolicTableMatch> matched_entries;
+};
+
+// The result of solving the symbolic state with some assertion.
+// This contains an input test packet, with its predicted flow in the program,
+// and the predicted output.
+struct ConcreteContext {
+  int ingress_port;
+  int egress_port;
+  ConcreteHeader ingress_packet;  // Input packet into the program/switch.
+  ConcreteHeader egress_packet;  // Expected output packet.
+  ConcreteTrace trace;  // Expected trace in the program.
+};
+
+// The symbolic context within our analysis.
+// Exposes symbolic handles for the fields of the input packet,
+// and its trace in the program.
+// Assertions are defined on a symbolic context.
+struct SymbolicContext {
+  z3::expr ingress_port;
+  z3::expr egress_port;
+  SymbolicHeader ingress_packet;
+  SymbolicHeader egress_packet;
+  SymbolicTrace trace;
+};
+
+// Maps the name of a table to a list of its entries.
+// Used as input to our symbolic pipeline.
+using ConcreteState =
+    std::unordered_map<std::string, std::vector<ir::TableEntry>>;
+
+// The overall state of our symbolic analysis.
+// This is returned by our main analysis/interpration function, and is used
+// to find concrete test packets and for debugging.
+// This is internal to our solver code. External code that uses our solver
+// is not expected to access any of these fields or modify them.
+struct SymbolicState {
+  // The IR represnetation of the p4 program being analyzed.
+  ir::P4Program program;
+  // The symbolic context of our interpretation/analysis of the program,
+  // including symbolic handles on packet headers and its trace.
+  SymbolicContext context;
+  // Having the z3 solver defined here allows Z3 to remember interesting
+  // deductions it made while solving for one particular assertion, and re-use
+  // them during solving with future assertions.
+  std::unique_ptr<z3::solver> solver;
+};
+
+// An assertion is a user defined function that takes a symbolic context
+// as input, and returns constraints on symbolic handles exposed by that
+// context. For example:
+// z3::expr portIsOne(const SymbolicContext &ctx) {
+//   return ctx.ingress_port == 1;
+// }
+using Assertion = std::function<z3::expr(const SymbolicContext&)>;
+
+// Symbolically runs/interprets the given program against the given
+// entries for every table in that program, and the available physical ports
+// on the switch.
+pdpi::StatusOr<SymbolicState> RunP4Pipeline(
+    const ir::P4Program &program, const ConcreteState &table_entries,
+    const std::vector<int> &physical_ports);
+
+// Finds a concrete packet and flow in the program that satisfies the given
+// assertion and meets the structure constrained by symbolic_state.
+pdpi::StatusOr<ConcreteContext> Solve(const SymbolicState &symbolic_state,
+                                      const Assertion &assertion);
+
+// Dumps the underlying SMT program for debugging.
+std::string DebugSMT(const SymbolicState &symbolic_state);
+
+// clean up Z3 internal memory datastructures, Z3 can still be
+// used after this, as if Z3 has been freshly loaded.
+// https://github.com/Z3Prover/z3/issues/157
+void CleanUpMemory();
+
+}  // namespace symbolic
+}  // namespace p4_symbolic
+
+#endif  // P4_SYMBOLIC_SYMBOLIC_SYMBOLIC_H_

--- a/p4_symbolic/symbolic/symbolic.h
+++ b/p4_symbolic/symbolic/symbolic.h
@@ -93,7 +93,6 @@ struct SymbolicHeader {
 
   z3::expr icmp_type;  // 8 bit, valid if eth_type is ip
   z3::expr vid;        // 12 bit, valid if eth_type = 0x6007
-
 };
 
 // The symbolic counterpart of ConcreteMetadata. This can be used to constrain
@@ -146,7 +145,7 @@ struct ConcreteContext {
   int ingress_port;
   int egress_port;
   ConcreteHeader ingress_packet;  // Input packet into the program/switch.
-  ConcreteHeader egress_packet;  // Expected output packet.
+  ConcreteHeader egress_packet;   // Expected output packet.
   // Expected metadata field values at the end of execution.
   // E.g. if vrf is set to different values through out the execution of the
   // program on this packet, this will contain the last value set for the vrf.
@@ -198,9 +197,7 @@ struct SolverState {
   // Makes sense to use here, when SolverState is destructed, it means
   // no further analysis of the particular program is possible.
   // https://github.com/Z3Prover/z3/issues/157
-  ~SolverState() {
-    Z3_API Z3_reset_memory();
-  }
+  ~SolverState() { Z3_API Z3_reset_memory(); }
 };
 
 // Instances of these structs are passed around and returned between our
@@ -222,14 +219,13 @@ struct IntermediateStateAndMatch {
 // z3::expr portIsOne(const SymbolicContext &ctx) {
 //   return ctx.ingress_port == 1;
 // }
-using Assertion = std::function<z3::expr(const SymbolicContext&)>;
+using Assertion = std::function<z3::expr(const SymbolicContext &)>;
 
 // Symbolically evaluates/interprets the given program against the given
 // entries for every table in that program, and the available physical ports
 // on the switch.
 pdpi::StatusOr<SolverState> EvaluateP4Pipeline(
-    const Dataplane &data_plane,
-    const std::vector<int> &physical_ports);
+    const Dataplane &data_plane, const std::vector<int> &physical_ports);
 
 // Finds a concrete packet and flow in the program that satisfies the given
 // assertion and meets the structure constrained by solver_state.

--- a/p4_symbolic/symbolic/table.h
+++ b/p4_symbolic/symbolic/table.h
@@ -1,0 +1,44 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contains functions used to symbolically run/interpret/analyze P4 tables and
+// their entries.
+// A table is turned into a sequence of if-conditions (one per entry),
+// each condition corresponds to having that entry matched on, and the
+// corresponding then body invokes the appropriate symbolic action expression
+// with the parameters specified in the entry.
+
+#ifndef P4_SYMBOLIC_SYMBOLIC_TABLE_H_
+#define P4_SYMBOLIC_SYMBOLIC_TABLE_H_
+
+#include <vector>
+
+#include "p4_pdpi/utils/status_utils.h"
+#include "p4_symbolic/ir/ir.pb.h"
+#include "p4_symbolic/symbolic/symbolic.h"
+#include "z3++.h"
+
+namespace p4_symbolic {
+namespace symbolic {
+namespace table {
+
+pdpi::StatusOr<SymbolicState> RunTable(
+    const ir::Table &table, const std::vector<ir::TableEntry> &entries,
+    const SymbolicState &state);
+
+}  // namespace table
+}  // namespace symbolic
+}  // namespace p4_symbolic
+
+#endif  // P4_SYMBOLIC_SYMBOLIC_TABLE_H_

--- a/p4_symbolic/symbolic/table.h
+++ b/p4_symbolic/symbolic/table.h
@@ -23,6 +23,7 @@
 
 #include <vector>
 
+#include "google/protobuf/map.h"
 #include "p4_pdpi/utils/status_utils.h"
 #include "p4_symbolic/ir/ir.pb.h"
 #include "p4_symbolic/symbolic/symbolic.h"
@@ -32,9 +33,15 @@ namespace p4_symbolic {
 namespace symbolic {
 namespace table {
 
-pdpi::StatusOr<IntermediateStateAndMatch> EvaluateTable(
+struct SymbolicPerPacketStateAndMatch {
+  SymbolicPerPacketState state;
+  SymbolicTableMatch match;
+};
+
+pdpi::StatusOr<SymbolicPerPacketStateAndMatch> EvaluateTable(
     const ir::Table &table, const std::vector<ir::TableEntry> &entries,
-    const IntermediateState &state);
+    const google::protobuf::Map<std::string, ir::Action> &actions,
+    const SymbolicPerPacketState &state);
 
 }  // namespace table
 }  // namespace symbolic

--- a/p4_symbolic/symbolic/table.h
+++ b/p4_symbolic/symbolic/table.h
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Contains functions used to symbolically run/interpret/analyze P4 tables and
-// their entries.
+// Contains functions used to symbolically evaluate P4 tables and their entries.
 // A table is turned into a sequence of if-conditions (one per entry),
 // each condition corresponds to having that entry matched on, and the
 // corresponding then body invokes the appropriate symbolic action expression
@@ -33,9 +32,9 @@ namespace p4_symbolic {
 namespace symbolic {
 namespace table {
 
-pdpi::StatusOr<SymbolicState> RunTable(
+pdpi::StatusOr<IntermediateStateAndMatch> EvaluateTable(
     const ir::Table &table, const std::vector<ir::TableEntry> &entries,
-    const SymbolicState &state);
+    const IntermediateState &state);
 
 }  // namespace table
 }  // namespace symbolic


### PR DESCRIPTION
This is a "fake" PR, it does not compile, it will not really be merged directly.

This PR contains the header files for the new structuring of our symbolic solver and interprater.

When approved, these header files will be used in the end2end PR and the source code will be updated to follow their structure.

p4_symbolic/symbolic/symbolic.h is the API-exposing header file, this needs to be used included and used by enclosing code that wants to use our solver.

symbolic.h/SymbolicState and the internal functions in action.h may still be extended/changed in end2end as necessary. The rest is fixed.