### PR TITLE
Add support for remaining P4 features to our IR and its parsing code.

### DIFF
--- a/p4-samples/ipv4-routing/.gitignore
+++ b/p4-samples/ipv4-routing/.gitignore
@@ -2,4 +2,4 @@
 *.p4i
 *.log
 *.pid
-*.pb.txt
+basic.pb.txt

--- a/p4-samples/ipv4-routing/basic.p4
+++ b/p4-samples/ipv4-routing/basic.p4
@@ -113,12 +113,12 @@ control MyIngress(inout headers hdr,
     
     table ipv4_lpm {
         key = {
-            hdr.ipv4.dstAddr: lpm;
+            hdr.ipv4.dstAddr: lpm @format(IPV4_ADDRESS);
         }
         actions = {
-            ipv4_forward;
-            drop;
-            NoAction;
+            @proto_id(1) ipv4_forward;
+            @proto_id(2) drop;
+            @proto_id(3) NoAction;
         }
         size = 1024;
         default_action = drop();

--- a/p4-samples/ipv4-routing/entries.pb.txt
+++ b/p4-samples/ipv4-routing/entries.pb.txt
@@ -26,7 +26,7 @@ table_entries {
   match {
     field_id: 1,    
     lpm {
-      value: "\020\020\000\000",
+      value: "\024\024\000\000",
       prefix_len: 16
     }    
   }
@@ -35,7 +35,7 @@ table_entries {
       action_id: 28792405
       params {
         param_id: 1
-        value: "\022\000\000\000\000\022"
+        value: "\026\000\000\000\000\026"
       }
       params {
         param_id: 2

--- a/p4-samples/ipv4-routing/entries.pb.txt
+++ b/p4-samples/ipv4-routing/entries.pb.txt
@@ -1,0 +1,46 @@
+table_entries {
+  table_id: 37375156
+  match {
+    field_id: 1,
+    lpm {
+      value: "\n\n\000\000",
+      prefix_len: 16
+    }    
+  }
+  action {
+    action {
+      action_id: 28792405
+      params {
+        param_id: 1
+        value: "\000\000\000\000\000\000"
+      }
+      params {
+        param_id: 2
+        value: "\00"
+      }
+    }
+  }
+}
+table_entries {
+  table_id: 37375156
+  match {
+    field_id: 1,    
+    lpm {
+      value: "\020\020\000\000",
+      prefix_len: 16
+    }    
+  }
+  action {
+    action {
+      action_id: 28792405
+      params {
+        param_id: 1
+        value: "\022\000\000\000\000\022"
+      }
+      params {
+        param_id: 2
+        value: "\01"
+      }
+    }
+  }
+}

--- a/p4_symbolic/bmv2/bmv2.proto
+++ b/p4_symbolic/bmv2/bmv2.proto
@@ -291,4 +291,5 @@ enum ExpressionType {
   unsupported_expression = 0;  // Something else that is not supported.
   field = 1;                   // Header/metadata field.
   runtime_data = 2;            // Local variable.
+  hexstr_ = 3;                 // Hexstring literal.
 }

--- a/p4_symbolic/bmv2/bmv2.proto
+++ b/p4_symbolic/bmv2/bmv2.proto
@@ -211,8 +211,8 @@ message Table {
   repeated string actions = 9;
   // Default table entry, which gets matched on if no other entry was matched.
   DefaultTableEntry default_entry = 10;
-  // Map between action name and the next flow (e.g. table, conditional etc)
-  // to be taken if an entry with that action was matched.
+  // Map between action name and the next control construct name (e.g. table,
+  // conditional etc) to be taken if an entry with that action was matched.
   map<string, string> next_tables = 11;
 }
 
@@ -253,7 +253,7 @@ message Conditional {
   string name = 2;
   // Condition expression.
   google.protobuf.Struct expression = 3;
-  // Name of the next control flow construct (table or conditional)
+  // Name of the next control construct (table or conditional)
   // invoked by each branch.
   string true_next = 4;
   string false_next = 5;

--- a/p4_symbolic/bmv2/bmv2.proto
+++ b/p4_symbolic/bmv2/bmv2.proto
@@ -177,6 +177,8 @@ message Pipeline {
   string init_table = 4;
   // All the tables and their actions that are part of this pipeline.
   repeated Table tables = 5;
+  // All the conditional statements in this pipeline.
+  repeated Conditional conditionals = 6;
 }
 
 // A control plane table definition including its keys and actions.
@@ -238,6 +240,22 @@ message DefaultTableEntry {
   repeated string action_data = 2;
 }
 
+// A conditional is the BMV2 representation of an if statement condition.
+// The body of the if and else branches are implicitly translated by p4c
+// into a table or action as is appropriate, and refered to here.
+message Conditional {
+  // Unique among all conditionals in the program.
+  int32 id = 1;
+  // Unique among conditionals and tables.
+  string name = 2;
+  // Condition expression.
+  google.protobuf.Struct expression = 3;
+  // Name of the next control flow construct (table or conditional)
+  // invoked by each branch.
+  string true_next = 4;
+  string false_next = 5;
+}
+
 // An action that can be taken when a table is matched on.
 message Action {
   // The name assigned by programmer.
@@ -290,16 +308,17 @@ message SourceLocation {
 // The names used inside the enum match *exactly* the values of the "op" field
 // in the respective statement JSON objects.
 enum StatementOp {
-  unsupported_statement = 0;  // Something else that is not supported.
-  assign = 1;                 // Assignment (to a variable or header field).
+  assign = 0;  // Assignment (to a variable or header field).
 }
 
 // This specifies the exact expressions that are supported by our ir.
 // The names used inside the enum match *exactly* the values of the "type" field
 // in the respective expression (e.g. type-value) JSON objects.
 enum ExpressionType {
-  unsupported_expression = 0;  // Something else that is not supported.
-  field = 1;                   // Header/metadata field.
-  runtime_data = 2;            // Local variable.
-  hexstr_ = 3;                 // Hexstring literal.
+  field = 0;         // Header/metadata field.
+  runtime_data = 1;  // Local variable.
+  hexstr_ = 2;       // Hexstring literal.
+  bool_ = 3;         // A boolean literal.
+  string_ = 4;       // A string literal.
+  expression = 5;    // An expression.
 }

--- a/p4_symbolic/bmv2/bmv2.proto
+++ b/p4_symbolic/bmv2/bmv2.proto
@@ -211,6 +211,9 @@ message Table {
   repeated string actions = 9;
   // Default table entry, which gets matched on if no other entry was matched.
   DefaultTableEntry default_entry = 10;
+  // Map between action name and the next flow (e.g. table, conditional etc)
+  // to be taken if an entry with that action was matched.
+  map<string, string> next_tables = 11;
 }
 
 // A table key represents an input-matching column

--- a/p4_symbolic/bmv2/bmv2.proto
+++ b/p4_symbolic/bmv2/bmv2.proto
@@ -311,17 +311,25 @@ message SourceLocation {
 // The names used inside the enum match *exactly* the values of the "op" field
 // in the respective statement JSON objects.
 enum StatementOp {
-  assign = 0;  // Assignment (to a variable or header field).
+  // Assignment (to a variable or header field).
+  assign = 0;
+  // Mark packet to be dropped.
+  mark_to_drop = 1;
+  // Modify a field via a hash calculation.
+  modify_field_with_hash_based_offset = 2;
+  // Cloning a packet.
+  clone_ingress_pkt_to_egress = 3;
 }
 
 // This specifies the exact expressions that are supported by our ir.
 // The names used inside the enum match *exactly* the values of the "type" field
 // in the respective expression (e.g. type-value) JSON objects.
 enum ExpressionType {
-  field = 0;         // Header/metadata field.
-  runtime_data = 1;  // Local variable.
-  hexstr_ = 2;       // Hexstring literal.
-  bool_ = 3;         // A boolean literal.
-  string_ = 4;       // A string literal.
-  expression = 5;    // An expression.
+  header = 0;        // A whole header accessed by name.
+  field = 1;         // Header/metadata field.
+  runtime_data = 2;  // Local variable.
+  hexstr_ = 3;       // Hexstring literal.
+  bool_ = 4;         // A boolean literal.
+  string_ = 5;       // A string literal.
+  expression = 6;    // An expression.
 }

--- a/p4_symbolic/bmv2/bmv2.proto
+++ b/p4_symbolic/bmv2/bmv2.proto
@@ -207,6 +207,8 @@ message Table {
   // that contain the name and the id of each action.
   repeated int32 action_ids = 8;
   repeated string actions = 9;
+  // Default table entry, which gets matched on if no other entry was matched.
+  DefaultTableEntry default_entry = 10;
 }
 
 // A table key represents an input-matching column
@@ -227,6 +229,15 @@ message TableKey {
   repeated string target = 4;
 }
 
+// A default table entry is the entry that gets matched on if no other actual
+// entry for that table was matched.
+message DefaultTableEntry {
+  // Target action id.
+  int32 action_id = 1;
+  // Arguments passed to the action (all hexstrings).
+  repeated string action_data = 2;
+}
+
 // An action that can be taken when a table is matched on.
 message Action {
   // The name assigned by programmer.
@@ -235,8 +246,7 @@ message Action {
   // This is auto-generated and unique among all actions. It is not the same
   // id used in P4info and P4RT.
   int32 id = 2;
-  // An array containing all variables defined within this action,
-  // including its formal parameters.
+  // An array containing all parameters defined by this action.
   repeated VariableDefinition runtime_data = 3;
   // An array of statements within the action body.
   // A statement that uses a variable/parameter in the p4 program

--- a/p4_symbolic/bmv2/expected/basic.pb.txt
+++ b/p4_symbolic/bmv2/expected/basic.pb.txt
@@ -983,6 +983,75 @@ pipelines {
     default_entry {
       action_id: 1
     }
+    next_tables {
+      key: "MyIngress.drop"
+      value: ""
+    }
+    next_tables {
+      key: "MyIngress.ipv4_forward"
+      value: ""
+    }
+    next_tables {
+      key: "NoAction"
+      value: ""
+    }
+  }
+  conditionals {
+    name: "node_2"
+    expression {
+      fields {
+        key: "type"
+        value {
+          string_value: "expression"
+        }
+      }
+      fields {
+        key: "value"
+        value {
+          struct_value {
+            fields {
+              key: "left"
+              value {
+                null_value: NULL_VALUE
+              }
+            }
+            fields {
+              key: "op"
+              value {
+                string_value: "d2b"
+              }
+            }
+            fields {
+              key: "right"
+              value {
+                struct_value {
+                  fields {
+                    key: "type"
+                    value {
+                      string_value: "field"
+                    }
+                  }
+                  fields {
+                    key: "value"
+                    value {
+                      list_value {
+                        values {
+                          string_value: "ipv4"
+                        }
+                        values {
+                          string_value: "$valid$"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    true_next: "MyIngress.ipv4_lpm"
   }
 }
 pipelines {

--- a/p4_symbolic/bmv2/expected/basic.pb.txt
+++ b/p4_symbolic/bmv2/expected/basic.pb.txt
@@ -980,6 +980,9 @@ pipelines {
     actions: "MyIngress.ipv4_forward"
     actions: "MyIngress.drop"
     actions: "NoAction"
+    default_entry {
+      action_id: 1
+    }
   }
 }
 pipelines {

--- a/p4_symbolic/bmv2/expected/hardcoded.pb.txt
+++ b/p4_symbolic/bmv2/expected/hardcoded.pb.txt
@@ -418,6 +418,10 @@ pipelines {
     actions: "hardcoded55"
     default_entry {
     }
+    next_tables {
+      key: "hardcoded55"
+      value: ""
+    }
   }
   tables {
     name: "tbl_hardcoded57"
@@ -434,6 +438,81 @@ pipelines {
     default_entry {
       action_id: 1
     }
+    next_tables {
+      key: "hardcoded57"
+      value: ""
+    }
+  }
+  conditionals {
+    name: "node_2"
+    expression {
+      fields {
+        key: "type"
+        value {
+          string_value: "expression"
+        }
+      }
+      fields {
+        key: "value"
+        value {
+          struct_value {
+            fields {
+              key: "left"
+              value {
+                struct_value {
+                  fields {
+                    key: "type"
+                    value {
+                      string_value: "field"
+                    }
+                  }
+                  fields {
+                    key: "value"
+                    value {
+                      list_value {
+                        values {
+                          string_value: "standard_metadata"
+                        }
+                        values {
+                          string_value: "ingress_port"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            fields {
+              key: "op"
+              value {
+                string_value: "=="
+              }
+            }
+            fields {
+              key: "right"
+              value {
+                struct_value {
+                  fields {
+                    key: "type"
+                    value {
+                      string_value: "hexstr"
+                    }
+                  }
+                  fields {
+                    key: "value"
+                    value {
+                      string_value: "0x0000"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    true_next: "tbl_hardcoded55"
+    false_next: "tbl_hardcoded57"
   }
 }
 pipelines {

--- a/p4_symbolic/bmv2/expected/hardcoded.pb.txt
+++ b/p4_symbolic/bmv2/expected/hardcoded.pb.txt
@@ -416,6 +416,8 @@ pipelines {
     max_size: 1024
     action_ids: 0
     actions: "hardcoded55"
+    default_entry {
+    }
   }
   tables {
     name: "tbl_hardcoded57"
@@ -429,6 +431,9 @@ pipelines {
     max_size: 1024
     action_ids: 1
     actions: "hardcoded57"
+    default_entry {
+      action_id: 1
+    }
   }
 }
 pipelines {

--- a/p4_symbolic/bmv2/expected/reflector.pb.txt
+++ b/p4_symbolic/bmv2/expected/reflector.pb.txt
@@ -334,6 +334,8 @@ pipelines {
     max_size: 1024
     action_ids: 0
     actions: "reflector54"
+    default_entry {
+    }
   }
 }
 pipelines {

--- a/p4_symbolic/bmv2/expected/reflector.pb.txt
+++ b/p4_symbolic/bmv2/expected/reflector.pb.txt
@@ -336,6 +336,10 @@ pipelines {
     actions: "reflector54"
     default_entry {
     }
+    next_tables {
+      key: "reflector54"
+      value: ""
+    }
   }
 }
 pipelines {

--- a/p4_symbolic/bmv2/expected/table.pb.txt
+++ b/p4_symbolic/bmv2/expected/table.pb.txt
@@ -344,6 +344,14 @@ pipelines {
     actions: "NoAction"
     default_entry {
     }
+    next_tables {
+      key: "MyIngress.set_egress_spec"
+      value: ""
+    }
+    next_tables {
+      key: "NoAction"
+      value: ""
+    }
   }
 }
 pipelines {

--- a/p4_symbolic/bmv2/expected/table.pb.txt
+++ b/p4_symbolic/bmv2/expected/table.pb.txt
@@ -342,6 +342,8 @@ pipelines {
     action_ids: 0
     actions: "MyIngress.set_egress_spec"
     actions: "NoAction"
+    default_entry {
+    }
   }
 }
 pipelines {

--- a/p4_symbolic/ir/BUILD.bazel
+++ b/p4_symbolic/ir/BUILD.bazel
@@ -84,6 +84,7 @@ cc_library(
         ":ir_cc_proto",
         ":table_entries",
         "//p4_symbolic/bmv2:bmv2_cc_proto",
+        "@com_github_p4lang_p4runtime//:p4runtime_cc_proto",
         "@com_google_absl//absl/strings",
         "@com_google_protobuf//:protobuf_headers",
         "@p4_pdpi//gutil:status",

--- a/p4_symbolic/ir/BUILD.bazel
+++ b/p4_symbolic/ir/BUILD.bazel
@@ -128,11 +128,9 @@ ir_parsing_test(
     p4_program = "//p4-samples:reflector/reflector.p4",
 )
 
-"""
 ir_parsing_test(
     name = "ipv4_routing_test",
     golden_file = "expected/basic.txt",
     p4_program = "//p4-samples:ipv4-routing/basic.p4",
     table_entries = "//p4-samples:ipv4-routing/entries.pb.txt",
 )
-"""

--- a/p4_symbolic/ir/BUILD.bazel
+++ b/p4_symbolic/ir/BUILD.bazel
@@ -115,3 +115,24 @@ ir_parsing_test(
     p4_program = "//p4-samples:port-table/table.p4",
     table_entries = "//p4-samples:port-table/entries.pb.txt",
 )
+
+ir_parsing_test(
+    name = "port_hardcoded_test",
+    golden_file = "expected/hardcoded.txt",
+    p4_program = "//p4-samples:hardcoded/hardcoded.p4",
+)
+
+ir_parsing_test(
+    name = "reflector_test",
+    golden_file = "expected/reflector.txt",
+    p4_program = "//p4-samples:reflector/reflector.p4",
+)
+
+"""
+ir_parsing_test(
+    name = "ipv4_routing_test",
+    golden_file = "expected/basic.txt",
+    p4_program = "//p4-samples:ipv4-routing/basic.p4",
+    table_entries = "//p4-samples:ipv4-routing/entries.pb.txt",
+)
+"""

--- a/p4_symbolic/ir/expected/basic.txt
+++ b/p4_symbolic/ir/expected/basic.txt
@@ -327,11 +327,11 @@ actions {
       }
     }
     action_implementation {
-      parameters {
+      parameter_to_bitwidth {
         key: "dstAddr"
         value: 48
       }
-      parameters {
+      parameter_to_bitwidth {
         key: "port"
         value: 9
       }

--- a/p4_symbolic/ir/expected/basic.txt
+++ b/p4_symbolic/ir/expected/basic.txt
@@ -607,7 +607,7 @@ conditionals {
     if_branch: "MyIngress.ipv4_lpm"
   }
 }
-initial_flow: "node_2"
+initial_control: "node_2"
 
 =====MyIngress.ipv4_lpm Entries=====
 

--- a/p4_symbolic/ir/expected/basic.txt
+++ b/p4_symbolic/ir/expected/basic.txt
@@ -1,0 +1,665 @@
+headers {
+  key: "ethernet_t"
+  value {
+    name: "ethernet_t"
+    id: 2
+    fields {
+      key: "dstAddr"
+      value {
+        name: "dstAddr"
+        bitwidth: 48
+      }
+    }
+    fields {
+      key: "etherType"
+      value {
+        name: "etherType"
+        bitwidth: 16
+      }
+    }
+    fields {
+      key: "srcAddr"
+      value {
+        name: "srcAddr"
+        bitwidth: 48
+      }
+    }
+  }
+}
+headers {
+  key: "ipv4_t"
+  value {
+    name: "ipv4_t"
+    id: 3
+    fields {
+      key: "diffserv"
+      value {
+        name: "diffserv"
+        bitwidth: 8
+      }
+    }
+    fields {
+      key: "dstAddr"
+      value {
+        name: "dstAddr"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "flags"
+      value {
+        name: "flags"
+        bitwidth: 3
+      }
+    }
+    fields {
+      key: "fragOffset"
+      value {
+        name: "fragOffset"
+        bitwidth: 13
+      }
+    }
+    fields {
+      key: "hdrChecksum"
+      value {
+        name: "hdrChecksum"
+        bitwidth: 16
+      }
+    }
+    fields {
+      key: "identification"
+      value {
+        name: "identification"
+        bitwidth: 16
+      }
+    }
+    fields {
+      key: "ihl"
+      value {
+        name: "ihl"
+        bitwidth: 4
+      }
+    }
+    fields {
+      key: "protocol"
+      value {
+        name: "protocol"
+        bitwidth: 8
+      }
+    }
+    fields {
+      key: "srcAddr"
+      value {
+        name: "srcAddr"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "totalLen"
+      value {
+        name: "totalLen"
+        bitwidth: 16
+      }
+    }
+    fields {
+      key: "ttl"
+      value {
+        name: "ttl"
+        bitwidth: 8
+      }
+    }
+    fields {
+      key: "version"
+      value {
+        name: "version"
+        bitwidth: 4
+      }
+    }
+  }
+}
+headers {
+  key: "scalars_0"
+  value {
+    name: "scalars_0"
+  }
+}
+headers {
+  key: "standard_metadata"
+  value {
+    name: "standard_metadata"
+    id: 1
+    fields {
+      key: "_padding"
+      value {
+        name: "_padding"
+        bitwidth: 3
+      }
+    }
+    fields {
+      key: "checksum_error"
+      value {
+        name: "checksum_error"
+        bitwidth: 1
+      }
+    }
+    fields {
+      key: "deq_qdepth"
+      value {
+        name: "deq_qdepth"
+        bitwidth: 19
+      }
+    }
+    fields {
+      key: "deq_timedelta"
+      value {
+        name: "deq_timedelta"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "egress_global_timestamp"
+      value {
+        name: "egress_global_timestamp"
+        bitwidth: 48
+      }
+    }
+    fields {
+      key: "egress_port"
+      value {
+        name: "egress_port"
+        bitwidth: 9
+      }
+    }
+    fields {
+      key: "egress_rid"
+      value {
+        name: "egress_rid"
+        bitwidth: 16
+      }
+    }
+    fields {
+      key: "egress_spec"
+      value {
+        name: "egress_spec"
+        bitwidth: 9
+      }
+    }
+    fields {
+      key: "enq_qdepth"
+      value {
+        name: "enq_qdepth"
+        bitwidth: 19
+      }
+    }
+    fields {
+      key: "enq_timestamp"
+      value {
+        name: "enq_timestamp"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "ingress_global_timestamp"
+      value {
+        name: "ingress_global_timestamp"
+        bitwidth: 48
+      }
+    }
+    fields {
+      key: "ingress_port"
+      value {
+        name: "ingress_port"
+        bitwidth: 9
+      }
+    }
+    fields {
+      key: "instance_type"
+      value {
+        name: "instance_type"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "mcast_grp"
+      value {
+        name: "mcast_grp"
+        bitwidth: 16
+      }
+    }
+    fields {
+      key: "packet_length"
+      value {
+        name: "packet_length"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "parser_error"
+      value {
+        name: "parser_error"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "priority"
+      value {
+        name: "priority"
+        bitwidth: 3
+      }
+    }
+  }
+}
+actions {
+  key: "MyIngress.drop"
+  value {
+    action_definition {
+      preamble {
+        id: 25652968
+        name: "MyIngress.drop"
+        alias: "drop"
+      }
+    }
+    action_implementation {
+      action_body {
+        source_info {
+          filename: "p4-samples/ipv4-routing/basic.p4"
+          line: 104
+          column: 8
+          source_fragment: "mark_to_drop(standard_metadata)"
+        }
+        drop {
+          header {
+            header_name: "standard_metadata"
+          }
+        }
+      }
+    }
+  }
+}
+actions {
+  key: "MyIngress.ipv4_forward"
+  value {
+    action_definition {
+      preamble {
+        id: 28792405
+        name: "MyIngress.ipv4_forward"
+        alias: "ipv4_forward"
+      }
+      params_by_id {
+        key: 1
+        value {
+          param {
+            id: 1
+            name: "dstAddr"
+            bitwidth: 48
+          }
+        }
+      }
+      params_by_id {
+        key: 2
+        value {
+          param {
+            id: 2
+            name: "port"
+            bitwidth: 9
+          }
+        }
+      }
+      params_by_name {
+        key: "dstAddr"
+        value {
+          param {
+            id: 1
+            name: "dstAddr"
+            bitwidth: 48
+          }
+        }
+      }
+      params_by_name {
+        key: "port"
+        value {
+          param {
+            id: 2
+            name: "port"
+            bitwidth: 9
+          }
+        }
+      }
+    }
+    action_implementation {
+      parameters {
+        key: "dstAddr"
+        value: 48
+      }
+      parameters {
+        key: "port"
+        value: 9
+      }
+      action_body {
+        source_info {
+          filename: "p4-samples/ipv4-routing/basic.p4"
+          line: 108
+          column: 8
+          source_fragment: "standard_metadata.egress_spec = port"
+        }
+        assignment {
+          left {
+            field_value {
+              header_name: "standard_metadata"
+              field_name: "egress_spec"
+            }
+          }
+          right {
+            variable_value {
+              name: "port"
+            }
+          }
+        }
+      }
+      action_body {
+        source_info {
+          filename: "p4-samples/ipv4-routing/basic.p4"
+          line: 109
+          column: 8
+          source_fragment: "hdr.ethernet.srcAddr = hdr.ethernet.dstAddr"
+        }
+        assignment {
+          left {
+            field_value {
+              header_name: "ethernet"
+              field_name: "srcAddr"
+            }
+          }
+          right {
+            field_value {
+              header_name: "ethernet"
+              field_name: "dstAddr"
+            }
+          }
+        }
+      }
+      action_body {
+        source_info {
+          filename: "p4-samples/ipv4-routing/basic.p4"
+          line: 110
+          column: 8
+          source_fragment: "hdr.ethernet.dstAddr = dstAddr"
+        }
+        assignment {
+          left {
+            field_value {
+              header_name: "ethernet"
+              field_name: "dstAddr"
+            }
+          }
+          right {
+            variable_value {
+              name: "dstAddr"
+            }
+          }
+        }
+      }
+      action_body {
+        source_info {
+          filename: "p4-samples/ipv4-routing/basic.p4"
+          line: 111
+          column: 8
+          source_fragment: "hdr.ipv4.ttl = hdr.ipv4.ttl - 1"
+        }
+        assignment {
+          left {
+            field_value {
+              header_name: "ipv4"
+              field_name: "ttl"
+            }
+          }
+          right {
+            expression_value {
+              binary_expression {
+                operation: BIT_AND
+                left {
+                  expression_value {
+                    binary_expression {
+                      left {
+                        field_value {
+                          header_name: "ipv4"
+                          field_name: "ttl"
+                        }
+                      }
+                      right {
+                        hexstr_value {
+                          value: "0xff"
+                        }
+                      }
+                    }
+                  }
+                }
+                right {
+                  hexstr_value {
+                    value: "0xff"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+actions {
+  key: "NoAction"
+  value {
+    action_definition {
+      preamble {
+        id: 21257015
+        name: "NoAction"
+        alias: "NoAction"
+        annotations: "@noWarn(\"unused\")"
+      }
+    }
+    action_implementation {
+    }
+  }
+}
+tables {
+  key: "MyIngress.ipv4_lpm"
+  value {
+    table_definition {
+      preamble {
+        id: 37375156
+        name: "MyIngress.ipv4_lpm"
+        alias: "ipv4_lpm"
+      }
+      match_fields_by_id {
+        key: 1
+        value {
+          match_field {
+            id: 1
+            name: "hdr.ipv4.dstAddr"
+            annotations: "@format(IPV4_ADDRESS)"
+            bitwidth: 32
+            match_type: LPM
+          }
+          format: IPV4
+        }
+      }
+      match_fields_by_name {
+        key: "hdr.ipv4.dstAddr"
+        value {
+          match_field {
+            id: 1
+            name: "hdr.ipv4.dstAddr"
+            annotations: "@format(IPV4_ADDRESS)"
+            bitwidth: 32
+            match_type: LPM
+          }
+          format: IPV4
+        }
+      }
+      actions {
+        ref {
+          id: 28792405
+          annotations: "@proto_id(1)"
+        }
+        action {
+          preamble {
+            id: 28792405
+            name: "MyIngress.ipv4_forward"
+            alias: "ipv4_forward"
+          }
+          params_by_id {
+            key: 1
+            value {
+              param {
+                id: 1
+                name: "dstAddr"
+                bitwidth: 48
+              }
+            }
+          }
+          params_by_id {
+            key: 2
+            value {
+              param {
+                id: 2
+                name: "port"
+                bitwidth: 9
+              }
+            }
+          }
+          params_by_name {
+            key: "dstAddr"
+            value {
+              param {
+                id: 1
+                name: "dstAddr"
+                bitwidth: 48
+              }
+            }
+          }
+          params_by_name {
+            key: "port"
+            value {
+              param {
+                id: 2
+                name: "port"
+                bitwidth: 9
+              }
+            }
+          }
+        }
+        proto_id: 1
+      }
+      actions {
+        ref {
+          id: 25652968
+          annotations: "@proto_id(2)"
+        }
+        action {
+          preamble {
+            id: 25652968
+            name: "MyIngress.drop"
+            alias: "drop"
+          }
+        }
+        proto_id: 2
+      }
+      actions {
+        ref {
+          id: 21257015
+          annotations: "@proto_id(3)"
+        }
+        action {
+          preamble {
+            id: 21257015
+            name: "NoAction"
+            alias: "NoAction"
+            annotations: "@noWarn(\"unused\")"
+          }
+        }
+        proto_id: 3
+      }
+      size: 1024
+    }
+    table_implementation {
+      default_action: "MyIngress.drop"
+    }
+  }
+}
+conditionals {
+  key: "node_2"
+  value {
+    name: "node_2"
+    condition {
+      expression_value {
+        builtin_expression {
+          function: DATA_TO_BOOL
+          arguments {
+            field_value {
+              header_name: "ipv4"
+              field_name: "$valid$"
+            }
+          }
+        }
+      }
+    }
+    if_branch: "MyIngress.ipv4_lpm"
+  }
+}
+initial_flow: "node_2"
+
+=====MyIngress.ipv4_lpm Entries=====
+
+table_name: "MyIngress.ipv4_lpm"
+matches {
+  name: "hdr.ipv4.dstAddr"
+  lpm {
+    value {
+      ipv4: "10.10.0.0"
+    }
+    prefix_length: 16
+  }
+}
+action {
+  name: "MyIngress.ipv4_forward"
+  params {
+    name: "dstAddr"
+    value {
+      hex_str: "0x000000000000"
+    }
+  }
+  params {
+    name: "port"
+    value {
+      hex_str: "0x0000"
+    }
+  }
+}
+
+table_name: "MyIngress.ipv4_lpm"
+matches {
+  name: "hdr.ipv4.dstAddr"
+  lpm {
+    value {
+      ipv4: "20.20.0.0"
+    }
+    prefix_length: 16
+  }
+}
+action {
+  name: "MyIngress.ipv4_forward"
+  params {
+    name: "dstAddr"
+    value {
+      hex_str: "0x160000000016"
+    }
+  }
+  params {
+    name: "port"
+    value {
+      hex_str: "0x0001"
+    }
+  }
+}
+

--- a/p4_symbolic/ir/expected/hardcoded.txt
+++ b/p4_symbolic/ir/expected/hardcoded.txt
@@ -1,0 +1,253 @@
+headers {
+  key: "scalars_0"
+  value {
+    name: "scalars_0"
+  }
+}
+headers {
+  key: "standard_metadata"
+  value {
+    name: "standard_metadata"
+    id: 1
+    fields {
+      key: "_padding"
+      value {
+        name: "_padding"
+        bitwidth: 3
+      }
+    }
+    fields {
+      key: "checksum_error"
+      value {
+        name: "checksum_error"
+        bitwidth: 1
+      }
+    }
+    fields {
+      key: "deq_qdepth"
+      value {
+        name: "deq_qdepth"
+        bitwidth: 19
+      }
+    }
+    fields {
+      key: "deq_timedelta"
+      value {
+        name: "deq_timedelta"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "egress_global_timestamp"
+      value {
+        name: "egress_global_timestamp"
+        bitwidth: 48
+      }
+    }
+    fields {
+      key: "egress_port"
+      value {
+        name: "egress_port"
+        bitwidth: 9
+      }
+    }
+    fields {
+      key: "egress_rid"
+      value {
+        name: "egress_rid"
+        bitwidth: 16
+      }
+    }
+    fields {
+      key: "egress_spec"
+      value {
+        name: "egress_spec"
+        bitwidth: 9
+      }
+    }
+    fields {
+      key: "enq_qdepth"
+      value {
+        name: "enq_qdepth"
+        bitwidth: 19
+      }
+    }
+    fields {
+      key: "enq_timestamp"
+      value {
+        name: "enq_timestamp"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "ingress_global_timestamp"
+      value {
+        name: "ingress_global_timestamp"
+        bitwidth: 48
+      }
+    }
+    fields {
+      key: "ingress_port"
+      value {
+        name: "ingress_port"
+        bitwidth: 9
+      }
+    }
+    fields {
+      key: "instance_type"
+      value {
+        name: "instance_type"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "mcast_grp"
+      value {
+        name: "mcast_grp"
+        bitwidth: 16
+      }
+    }
+    fields {
+      key: "packet_length"
+      value {
+        name: "packet_length"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "parser_error"
+      value {
+        name: "parser_error"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "priority"
+      value {
+        name: "priority"
+        bitwidth: 3
+      }
+    }
+  }
+}
+actions {
+  key: "hardcoded55"
+  value {
+    action_definition {
+      preamble {
+        name: "hardcoded55"
+      }
+    }
+    action_implementation {
+      action_body {
+        source_info {
+          filename: "p4-samples/hardcoded/hardcoded.p4"
+          line: 55
+          column: 12
+          source_fragment: "standard_metadata.egress_spec = 1"
+        }
+        assignment {
+          left {
+            field_value {
+              header_name: "standard_metadata"
+              field_name: "egress_spec"
+            }
+          }
+          right {
+            hexstr_value {
+              value: "0x0001"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+actions {
+  key: "hardcoded57"
+  value {
+    action_definition {
+      preamble {
+        id: 1
+        name: "hardcoded57"
+      }
+    }
+    action_implementation {
+      action_body {
+        source_info {
+          filename: "p4-samples/hardcoded/hardcoded.p4"
+          line: 57
+          column: 12
+          source_fragment: "standard_metadata.egress_spec = 0"
+        }
+        assignment {
+          left {
+            field_value {
+              header_name: "standard_metadata"
+              field_name: "egress_spec"
+            }
+          }
+          right {
+            hexstr_value {
+              value: "0x0000"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+tables {
+  key: "tbl_hardcoded55"
+  value {
+    table_definition {
+      preamble {
+        name: "tbl_hardcoded55"
+      }
+    }
+    table_implementation {
+      default_action: "hardcoded55"
+    }
+  }
+}
+tables {
+  key: "tbl_hardcoded57"
+  value {
+    table_definition {
+      preamble {
+        name: "tbl_hardcoded57"
+      }
+    }
+    table_implementation {
+      default_action: "hardcoded57"
+    }
+  }
+}
+conditionals {
+  key: "node_2"
+  value {
+    name: "node_2"
+    condition {
+      expression_value {
+        binary_expression {
+          operation: EQUALS
+          left {
+            field_value {
+              header_name: "standard_metadata"
+              field_name: "ingress_port"
+            }
+          }
+          right {
+            hexstr_value {
+              value: "0x0000"
+            }
+          }
+        }
+      }
+    }
+    if_branch: "tbl_hardcoded55"
+    else_branch: "tbl_hardcoded57"
+  }
+}
+initial_flow: "node_2"
+

--- a/p4_symbolic/ir/expected/hardcoded.txt
+++ b/p4_symbolic/ir/expected/hardcoded.txt
@@ -249,5 +249,5 @@ conditionals {
     else_branch: "tbl_hardcoded57"
   }
 }
-initial_flow: "node_2"
+initial_control: "node_2"
 

--- a/p4_symbolic/ir/expected/reflector.txt
+++ b/p4_symbolic/ir/expected/reflector.txt
@@ -177,5 +177,5 @@ tables {
     }
   }
 }
-initial_flow: "tbl_reflector54"
+initial_control: "tbl_reflector54"
 

--- a/p4_symbolic/ir/expected/reflector.txt
+++ b/p4_symbolic/ir/expected/reflector.txt
@@ -1,0 +1,181 @@
+headers {
+  key: "scalars_0"
+  value {
+    name: "scalars_0"
+  }
+}
+headers {
+  key: "standard_metadata"
+  value {
+    name: "standard_metadata"
+    id: 1
+    fields {
+      key: "_padding"
+      value {
+        name: "_padding"
+        bitwidth: 3
+      }
+    }
+    fields {
+      key: "checksum_error"
+      value {
+        name: "checksum_error"
+        bitwidth: 1
+      }
+    }
+    fields {
+      key: "deq_qdepth"
+      value {
+        name: "deq_qdepth"
+        bitwidth: 19
+      }
+    }
+    fields {
+      key: "deq_timedelta"
+      value {
+        name: "deq_timedelta"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "egress_global_timestamp"
+      value {
+        name: "egress_global_timestamp"
+        bitwidth: 48
+      }
+    }
+    fields {
+      key: "egress_port"
+      value {
+        name: "egress_port"
+        bitwidth: 9
+      }
+    }
+    fields {
+      key: "egress_rid"
+      value {
+        name: "egress_rid"
+        bitwidth: 16
+      }
+    }
+    fields {
+      key: "egress_spec"
+      value {
+        name: "egress_spec"
+        bitwidth: 9
+      }
+    }
+    fields {
+      key: "enq_qdepth"
+      value {
+        name: "enq_qdepth"
+        bitwidth: 19
+      }
+    }
+    fields {
+      key: "enq_timestamp"
+      value {
+        name: "enq_timestamp"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "ingress_global_timestamp"
+      value {
+        name: "ingress_global_timestamp"
+        bitwidth: 48
+      }
+    }
+    fields {
+      key: "ingress_port"
+      value {
+        name: "ingress_port"
+        bitwidth: 9
+      }
+    }
+    fields {
+      key: "instance_type"
+      value {
+        name: "instance_type"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "mcast_grp"
+      value {
+        name: "mcast_grp"
+        bitwidth: 16
+      }
+    }
+    fields {
+      key: "packet_length"
+      value {
+        name: "packet_length"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "parser_error"
+      value {
+        name: "parser_error"
+        bitwidth: 32
+      }
+    }
+    fields {
+      key: "priority"
+      value {
+        name: "priority"
+        bitwidth: 3
+      }
+    }
+  }
+}
+actions {
+  key: "reflector54"
+  value {
+    action_definition {
+      preamble {
+        name: "reflector54"
+      }
+    }
+    action_implementation {
+      action_body {
+        source_info {
+          filename: "p4-samples/reflector/reflector.p4"
+          line: 54
+          column: 8
+          source_fragment: "standard_metadata.egress_spec = standard_metadata.ingress_port"
+        }
+        assignment {
+          left {
+            field_value {
+              header_name: "standard_metadata"
+              field_name: "egress_spec"
+            }
+          }
+          right {
+            field_value {
+              header_name: "standard_metadata"
+              field_name: "ingress_port"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+tables {
+  key: "tbl_reflector54"
+  value {
+    table_definition {
+      preamble {
+        name: "tbl_reflector54"
+      }
+    }
+    table_implementation {
+      default_action: "reflector54"
+    }
+  }
+}
+initial_flow: "tbl_reflector54"
+

--- a/p4_symbolic/ir/expected/table.txt
+++ b/p4_symbolic/ir/expected/table.txt
@@ -161,7 +161,7 @@ actions {
       }
     }
     action_implementation {
-      variables {
+      parameters {
         key: "port"
         value: 9
       }
@@ -287,6 +287,7 @@ tables {
       size: 1024
     }
     table_implementation {
+      default_action: "NoAction"
     }
   }
 }

--- a/p4_symbolic/ir/expected/table.txt
+++ b/p4_symbolic/ir/expected/table.txt
@@ -291,7 +291,7 @@ tables {
     }
   }
 }
-initial_flow: "MyIngress.ports_exact"
+initial_control: "MyIngress.ports_exact"
 
 =====MyIngress.ports_exact Entries=====
 

--- a/p4_symbolic/ir/expected/table.txt
+++ b/p4_symbolic/ir/expected/table.txt
@@ -161,7 +161,7 @@ actions {
       }
     }
     action_implementation {
-      parameters {
+      parameter_to_bitwidth {
         key: "port"
         value: 9
       }

--- a/p4_symbolic/ir/expected/table.txt
+++ b/p4_symbolic/ir/expected/table.txt
@@ -291,7 +291,7 @@ tables {
     }
   }
 }
-initial_table: "MyIngress.ports_exact"
+initial_flow: "MyIngress.ports_exact"
 
 =====MyIngress.ports_exact Entries=====
 

--- a/p4_symbolic/ir/ir.cc
+++ b/p4_symbolic/ir/ir.cc
@@ -30,14 +30,15 @@ namespace ir {
 
 namespace {
 
-// Signature of ExtractRValue defined below.
+// Forward declaration to enable mutual recursion with (sub) expression parsing
+// functions, e.g. ExtractBinaryExpression, ExtractUnaryExpression, etc.
 gutil::StatusOr<RValue> ExtractRValue(
     const google::protobuf::Value &bmv2_value,
     const std::vector<std::string> &variables);
 
 // Translate a string statement op to its respective enum value.
 gutil::StatusOr<bmv2::StatementOp> StatementOpToEnum(const std::string &op) {
-  static std::unordered_map<std::string, bmv2::StatementOp> op_table = {
+  static const std::unordered_map<std::string, bmv2::StatementOp> op_table = {
       {"assign", bmv2::StatementOp::assign},
       {"mark_to_drop", bmv2::StatementOp::mark_to_drop},
       {"clone_ingress_pkt_to_egress",  // clone3(...)
@@ -46,8 +47,8 @@ gutil::StatusOr<bmv2::StatementOp> StatementOpToEnum(const std::string &op) {
        bmv2::StatementOp::modify_field_with_hash_based_offset}};
 
   if (op_table.count(op) != 1) {
-    return absl::Status(absl::StatusCode::kUnimplemented,
-                        absl::StrCat("Unsupported statement op ", op));
+    return absl::UnimplementedError(
+        absl::StrCat("Unsupported statement op ", op));
   }
   return op_table.at(op);
 }
@@ -55,18 +56,18 @@ gutil::StatusOr<bmv2::StatementOp> StatementOpToEnum(const std::string &op) {
 // Translate a string expression type to its respective enum value.
 gutil::StatusOr<bmv2::ExpressionType> ExpressionTypeToEnum(
     const std::string &type) {
-  static std::unordered_map<std::string, bmv2::ExpressionType> type_table = {
-      {"header", bmv2::ExpressionType::header},
-      {"field", bmv2::ExpressionType::field},
-      {"runtime_data", bmv2::ExpressionType::runtime_data},
-      {"hexstr", bmv2::ExpressionType::hexstr_},
-      {"bool", bmv2::ExpressionType::bool_},
-      {"string", bmv2::ExpressionType::string_},
-      {"expression", bmv2::ExpressionType::expression}};
+  static const std::unordered_map<std::string, bmv2::ExpressionType>
+      type_table = {{"header", bmv2::ExpressionType::header},
+                    {"field", bmv2::ExpressionType::field},
+                    {"runtime_data", bmv2::ExpressionType::runtime_data},
+                    {"hexstr", bmv2::ExpressionType::hexstr_},
+                    {"bool", bmv2::ExpressionType::bool_},
+                    {"string", bmv2::ExpressionType::string_},
+                    {"expression", bmv2::ExpressionType::expression}};
 
   if (type_table.count(type) != 1) {
-    return absl::Status(absl::StatusCode::kUnimplemented,
-                        absl::StrCat("Unsupported expression type ", type));
+    return absl::UnimplementedError(
+        absl::StrCat("Unsupported expression type ", type));
   }
   return type_table.at(type);
 }
@@ -74,36 +75,36 @@ gutil::StatusOr<bmv2::ExpressionType> ExpressionTypeToEnum(
 // Translate a string expression operation ("op") to its respective enum value.
 gutil::StatusOr<RExpression::ExpressionCase> ExpressionOpToCase(
     const std::string &op) {
-  static std::unordered_map<std::string, RExpression::ExpressionCase> table = {
-      // Binary expressions.
-      {"+", RExpression::ExpressionCase::kBinaryExpression},
-      {"-", RExpression::ExpressionCase::kBinaryExpression},
-      {"*", RExpression::ExpressionCase::kBinaryExpression},
-      {"<<", RExpression::ExpressionCase::kBinaryExpression},
-      {">>", RExpression::ExpressionCase::kBinaryExpression},
-      {"==", RExpression::ExpressionCase::kBinaryExpression},
-      {"!=", RExpression::ExpressionCase::kBinaryExpression},
-      {">", RExpression::ExpressionCase::kBinaryExpression},
-      {">=", RExpression::ExpressionCase::kBinaryExpression},
-      {"<", RExpression::ExpressionCase::kBinaryExpression},
-      {"<=", RExpression::ExpressionCase::kBinaryExpression},
-      {"and", RExpression::ExpressionCase::kBinaryExpression},
-      {"or", RExpression::ExpressionCase::kBinaryExpression},
-      {"&", RExpression::ExpressionCase::kBinaryExpression},
-      {"|", RExpression::ExpressionCase::kBinaryExpression},
-      {"^", RExpression::ExpressionCase::kBinaryExpression},
-      // Unary.
-      {"~", RExpression::ExpressionCase::kUnaryExpression},
-      {"not", RExpression::ExpressionCase::kUnaryExpression},
-      // Ternary.
-      {"?", RExpression::ExpressionCase::kTernaryExpression},
-      // Builtin functions.
-      {"b2d", RExpression::ExpressionCase::kBuiltinExpression},
-      {"d2b", RExpression::ExpressionCase::kBuiltinExpression}};
+  static const std::unordered_map<std::string, RExpression::ExpressionCase>
+      table = {// Binary expressions.
+               {"+", RExpression::ExpressionCase::kBinaryExpression},
+               {"-", RExpression::ExpressionCase::kBinaryExpression},
+               {"*", RExpression::ExpressionCase::kBinaryExpression},
+               {"<<", RExpression::ExpressionCase::kBinaryExpression},
+               {">>", RExpression::ExpressionCase::kBinaryExpression},
+               {"==", RExpression::ExpressionCase::kBinaryExpression},
+               {"!=", RExpression::ExpressionCase::kBinaryExpression},
+               {">", RExpression::ExpressionCase::kBinaryExpression},
+               {">=", RExpression::ExpressionCase::kBinaryExpression},
+               {"<", RExpression::ExpressionCase::kBinaryExpression},
+               {"<=", RExpression::ExpressionCase::kBinaryExpression},
+               {"and", RExpression::ExpressionCase::kBinaryExpression},
+               {"or", RExpression::ExpressionCase::kBinaryExpression},
+               {"&", RExpression::ExpressionCase::kBinaryExpression},
+               {"|", RExpression::ExpressionCase::kBinaryExpression},
+               {"^", RExpression::ExpressionCase::kBinaryExpression},
+               // Unary.
+               {"~", RExpression::ExpressionCase::kUnaryExpression},
+               {"not", RExpression::ExpressionCase::kUnaryExpression},
+               // Ternary.
+               {"?", RExpression::ExpressionCase::kTernaryExpression},
+               // Builtin functions.
+               {"b2d", RExpression::ExpressionCase::kBuiltinExpression},
+               {"d2b", RExpression::ExpressionCase::kBuiltinExpression}};
 
   if (table.count(op) != 1) {
-    return absl::Status(absl::StatusCode::kUnimplemented,
-                        absl::StrCat("Unsupported expression op ", op));
+    return absl::UnimplementedError(
+        absl::StrCat("Unsupported expression op ", op));
   }
 
   return table.at(op);
@@ -114,8 +115,7 @@ gutil::StatusOr<bmv2::SourceLocation> ExtractSourceLocation(
     google::protobuf::Value unparsed_source_location) {
   if (unparsed_source_location.kind_case() !=
       google::protobuf::Value::kStructValue) {
-    return absl::Status(
-        absl::StatusCode::kInvalidArgument,
+    return absl::InvalidArgumentError(
         absl::StrCat("Source Location is expected to be a struct, found ",
                      unparsed_source_location.DebugString()));
   }
@@ -123,8 +123,7 @@ gutil::StatusOr<bmv2::SourceLocation> ExtractSourceLocation(
   const auto &fields = unparsed_source_location.struct_value().fields();
   if (fields.count("filename") != 1 || fields.count("line") != 1 ||
       fields.count("column") != 1 || fields.count("source_fragment") != 1) {
-    return absl::Status(
-        absl::StatusCode::kInvalidArgument,
+    return absl::InvalidArgumentError(
         absl::StrCat("Source Location is expected to contain 'filename', "
                      "'line', 'colmn', and 'source_fragment, found ",
                      unparsed_source_location.DebugString()));
@@ -143,18 +142,15 @@ absl::Status ValidateHeaderTypeFields(const google::protobuf::ListValue &list) {
   // Size must be 3.
   int size = list.values_size();
   if (size != 3) {
-    return absl::Status(
-        absl::StatusCode::kInvalidArgument,
-        absl::StrCat("Header field should contain 3 elements, found ",
-                     list.DebugString()));
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Header field should contain 3 elements, found ", list.DebugString()));
   }
 
   // Array must contain [string, int, bool] in that order.
   if (list.values(0).kind_case() != google::protobuf::Value::kStringValue ||
       list.values(1).kind_case() != google::protobuf::Value::kNumberValue ||
       list.values(2).kind_case() != google::protobuf::Value::kBoolValue) {
-    return absl::Status(
-        absl::StatusCode::kInvalidArgument,
+    return absl::InvalidArgumentError(
         absl::StrCat("Header field should be [string, int, bool], found ",
                      list.DebugString()));
   }
@@ -183,7 +179,7 @@ gutil::StatusOr<HeaderType> ExtractHeaderType(const bmv2::HeaderType &header) {
 gutil::StatusOr<UnaryExpression> ExtractUnaryExpression(
     const google::protobuf::Struct &bmv2_expression,
     const std::vector<std::string> &variables) {
-  static std::unordered_map<std::string, UnaryExpression::Operation>
+  static const std::unordered_map<std::string, UnaryExpression::Operation>
       unary_op_table = {{"~", UnaryExpression::BIT_NEGATION},
                         {"not", UnaryExpression::NOT}};
 
@@ -201,7 +197,7 @@ gutil::StatusOr<UnaryExpression> ExtractUnaryExpression(
 gutil::StatusOr<BinaryExpression> ExtractBinaryExpression(
     const google::protobuf::Struct &bmv2_expression,
     const std::vector<std::string> &variables) {
-  static std::unordered_map<std::string, BinaryExpression::Operation>
+  static const std::unordered_map<std::string, BinaryExpression::Operation>
       binary_op_table = {{"+", BinaryExpression::PLUS},
                          {"-", BinaryExpression::MINUS},
                          {"*", BinaryExpression::TIMES},
@@ -220,8 +216,7 @@ gutil::StatusOr<BinaryExpression> ExtractBinaryExpression(
                          {"^", BinaryExpression::BIT_XOR}};
 
   if (bmv2_expression.fields().count("left") != 1) {
-    return absl::Status(
-        absl::StatusCode::kInvalidArgument,
+    return absl::InvalidArgumentError(
         absl::StrCat("BinaryExpression must contain 'left', found ",
                      bmv2_expression.DebugString()));
   }
@@ -244,11 +239,9 @@ gutil::StatusOr<TernaryExpression> ExtractTernaryExpression(
     const std::vector<std::string> &variables) {
   if (bmv2_expression.fields().count("left") != 1 ||
       bmv2_expression.fields().count("condition") != 1) {
-    return absl::Status(
-        absl::StatusCode::kInvalidArgument,
-        absl::StrCat(
-            "TernaryExpression must contain 'left' and 'condition', found ",
-            bmv2_expression.DebugString()));
+    return absl::InvalidArgumentError(
+        absl::StrCat("TernaryExpression must contain 'left', and 'condition' ",
+                     bmv2_expression.DebugString()));
   }
 
   const google::protobuf::Value &condition =
@@ -267,7 +260,7 @@ gutil::StatusOr<TernaryExpression> ExtractTernaryExpression(
 gutil::StatusOr<BuiltinExpression> ExtractBuiltinExpression(
     const google::protobuf::Struct &bmv2_expression,
     const std::vector<std::string> &variables) {
-  static std::unordered_map<std::string, BuiltinExpression::Function>
+  static const std::unordered_map<std::string, BuiltinExpression::Function>
       builtin_table = {{"b2d", BuiltinExpression::BOOL_TO_DATA},
                        {"d2b", BuiltinExpression::DATA_TO_BOOL}};
 
@@ -296,8 +289,7 @@ gutil::StatusOr<RExpression> ExtractRExpression(
   // Integrity check.
   if (bmv2_expression.fields().count("op") != 1 ||
       bmv2_expression.fields().count("right") != 1) {
-    return absl::Status(
-        absl::StatusCode::kInvalidArgument,
+    return absl::InvalidArgumentError(
         absl::StrCat("RExpression must contain 'op' and 'right', found ",
                      bmv2_expression.DebugString()));
   }
@@ -312,30 +304,27 @@ gutil::StatusOr<RExpression> ExtractRExpression(
     case RExpression::ExpressionCase::kUnaryExpression: {
       ASSIGN_OR_RETURN(*output.mutable_unary_expression(),
                        ExtractUnaryExpression(bmv2_expression, variables));
-      break;
+      return output;
     }
     case RExpression::ExpressionCase::kBinaryExpression: {
       ASSIGN_OR_RETURN(*output.mutable_binary_expression(),
                        ExtractBinaryExpression(bmv2_expression, variables));
-      break;
+      return output;
     }
     case RExpression::ExpressionCase::kTernaryExpression: {
       ASSIGN_OR_RETURN(*output.mutable_ternary_expression(),
                        ExtractTernaryExpression(bmv2_expression, variables));
-      break;
+      return output;
     }
     case RExpression::ExpressionCase::kBuiltinExpression: {
       ASSIGN_OR_RETURN(*output.mutable_builtin_expression(),
                        ExtractBuiltinExpression(bmv2_expression, variables));
-      break;
+      return output;
     }
     default:
-      return absl::Status(absl::StatusCode::kUnimplemented,
-                          absl::StrCat("Unsupported expression op ",
-                                       bmv2_expression.DebugString()));
+      return absl::UnimplementedError(absl::StrCat(
+          "Unsupported expression op ", bmv2_expression.DebugString()));
   }
-
-  return output;
 }
 
 // Functions for translating values.
@@ -347,8 +336,7 @@ gutil::StatusOr<LValue> ExtractLValue(
   if (bmv2_value.kind_case() != google::protobuf::Value::kStructValue ||
       bmv2_value.struct_value().fields().count("type") != 1 ||
       bmv2_value.struct_value().fields().count("value") != 1) {
-    return absl::Status(
-        absl::StatusCode::kInvalidArgument,
+    return absl::InvalidArgumentError(
         absl::StrCat("Lvalue must contain 'type' and 'value', found ",
                      bmv2_value.DebugString()));
   }
@@ -365,22 +353,19 @@ gutil::StatusOr<LValue> ExtractLValue(
       FieldValue *field_value = output.mutable_field_value();
       field_value->set_header_name(names.values(0).string_value());
       field_value->set_field_name(names.values(1).string_value());
-      break;
+      return output;
     }
     case bmv2::ExpressionType::runtime_data: {
       int variable_index = struct_value.fields().at("value").number_value();
 
       Variable *variable = output.mutable_variable_value();
       variable->set_name(variables[variable_index]);
-      break;
+      return output;
     }
     default:
-      return absl::Status(
-          absl::StatusCode::kUnimplemented,
+      return absl::UnimplementedError(
           absl::StrCat("Unsupported lvalue ", bmv2_value.DebugString()));
   }
-
-  return output;
 }
 
 gutil::StatusOr<RValue> ExtractRValue(
@@ -390,8 +375,7 @@ gutil::StatusOr<RValue> ExtractRValue(
   if (bmv2_value.kind_case() != google::protobuf::Value::kStructValue ||
       bmv2_value.struct_value().fields().count("type") != 1 ||
       bmv2_value.struct_value().fields().count("value") != 1) {
-    return absl::Status(
-        absl::StatusCode::kInvalidArgument,
+    return absl::InvalidArgumentError(
         absl::StrCat("Rvalue must contain 'type' and 'value', found ",
                      bmv2_value.DebugString()));
   }
@@ -407,7 +391,7 @@ gutil::StatusOr<RValue> ExtractRValue(
 
       HeaderValue *header_value = output.mutable_header_value();
       header_value->set_header_name(header_name);
-      break;
+      return output;
     }
     case bmv2::ExpressionType::field: {
       const google::protobuf::ListValue &names =
@@ -416,14 +400,14 @@ gutil::StatusOr<RValue> ExtractRValue(
       FieldValue *field_value = output.mutable_field_value();
       field_value->set_header_name(names.values(0).string_value());
       field_value->set_field_name(names.values(1).string_value());
-      break;
+      return output;
     }
     case bmv2::ExpressionType::runtime_data: {
       int variable_index = struct_value.fields().at("value").number_value();
 
       Variable *variable = output.mutable_variable_value();
       variable->set_name(variables[variable_index]);
-      break;
+      return output;
     }
     case bmv2::ExpressionType::hexstr_: {
       HexstrValue *hexstr_value = output.mutable_hexstr_value();
@@ -435,17 +419,17 @@ gutil::StatusOr<RValue> ExtractRValue(
         hexstr_value->set_value(hexstr);
         hexstr_value->set_negative(false);
       }
-      break;
+      return output;
     }
     case bmv2::ExpressionType::bool_: {
       output.mutable_bool_value()->set_value(
           struct_value.fields().at("value").bool_value());
-      break;
+      return output;
     }
     case bmv2::ExpressionType::string_: {
       output.mutable_string_value()->set_value(
           struct_value.fields().at("value").string_value());
-      break;
+      return output;
     }
     case bmv2::ExpressionType::expression: {
       const google::protobuf::Struct *expression =
@@ -463,8 +447,7 @@ gutil::StatusOr<RValue> ExtractRValue(
         if (expression->fields().count("type") != 1 ||
             expression->fields().at("type").string_value() != "expression" ||
             expression->fields().count("value") != 1) {
-          return absl::Status(
-              absl::StatusCode::kInvalidArgument,
+          return absl::InvalidArgumentError(
               absl::StrCat("Expression must contain 'op' at some level, found ",
                            expression->DebugString()));
         }
@@ -473,15 +456,12 @@ gutil::StatusOr<RValue> ExtractRValue(
 
       ASSIGN_OR_RETURN(*(output.mutable_expression_value()),
                        ExtractRExpression(*expression, variables));
-      break;
+      return output;
     }
     default:
-      return absl::Status(
-          absl::StatusCode::kUnimplemented,
+      return absl::UnimplementedError(
           absl::StrCat("Unsupported rvalue ", bmv2_value.DebugString()));
   }
-
-  return output;
 }
 
 // Parsing and validating actions.
@@ -500,7 +480,7 @@ gutil::StatusOr<Action> ExtractAction(
   std::vector<std::string> parameter_map(bmv2_action.runtime_data_size());
   for (int i = 0; i < bmv2_action.runtime_data_size(); i++) {
     const bmv2::VariableDefinition parameter = bmv2_action.runtime_data(i);
-    (*action_impl->mutable_parameters())[parameter.name()] =
+    (*action_impl->mutable_parameter_to_bitwidth())[parameter.name()] =
         parameter.bitwidth();
     parameter_map[i] = parameter.name();
   }
@@ -510,12 +490,10 @@ gutil::StatusOr<Action> ExtractAction(
   for (const google::protobuf::Struct &primitive : bmv2_action.primitives()) {
     if (primitive.fields().count("op") != 1 ||
         primitive.fields().count("parameters") != 1) {
-      return absl::Status(absl::StatusCode::kInvalidArgument,
-                          absl::StrCat("Primitive statement in action ",
-                                       pdpi_action.preamble().name(),
-                                       " should contain 'op'"
-                                       ", 'parameters', found ",
-                                       primitive.DebugString()));
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Primitive statement in action ", pdpi_action.preamble().name(),
+          " should contain 'op', 'parameters', found ",
+          primitive.DebugString()));
     }
 
     Statement *statement = action_impl->add_action_body();
@@ -529,11 +507,9 @@ gutil::StatusOr<Action> ExtractAction(
             primitive.fields().at("parameters");
         if (params.kind_case() != google::protobuf::Value::kListValue ||
             params.list_value().values_size() != 2) {
-          return absl::Status(absl::StatusCode::kInvalidArgument,
-                              absl::StrCat("Assignment statement in action ",
-                                           pdpi_action.preamble().name(),
-                                           " must contain 2 parameters, found ",
-                                           primitive.DebugString()));
+          return absl::InvalidArgumentError(absl::StrCat(
+              "Assignment statement in action ", pdpi_action.preamble().name(),
+              " must contain 2 parameters, found ", primitive.DebugString()));
         }
 
         ASSIGN_OR_RETURN(
@@ -550,22 +526,20 @@ gutil::StatusOr<Action> ExtractAction(
             primitive.fields().at("parameters");
         if (params.kind_case() != google::protobuf::Value::kListValue ||
             params.list_value().values_size() != 1) {
-          return absl::Status(absl::StatusCode::kInvalidArgument,
-                              absl::StrCat("Mark to drop statement in action ",
-                                           pdpi_action.preamble().name(),
-                                           " must contain 1 parameter, found ",
-                                           primitive.DebugString()));
+          return absl::InvalidArgumentError(absl::StrCat(
+              "Mark to drop statement in action ",
+              pdpi_action.preamble().name(),
+              " must contain 1 parameter, found ", primitive.DebugString()));
         }
 
         ASSIGN_OR_RETURN(
             RValue drop_rvalue,
             ExtractRValue(params.list_value().values(0), parameter_map));
         if (drop_rvalue.rvalue_case() != RValue::kHeaderValue) {
-          return absl::Status(absl::StatusCode::kInvalidArgument,
-                              absl::StrCat("Mark to drop statement in action ",
-                                           pdpi_action.preamble().name(),
-                                           " must be passed a header, found ",
-                                           primitive.DebugString()));
+          return absl::InvalidArgumentError(absl::StrCat(
+              "Mark to drop statement in action ",
+              pdpi_action.preamble().name(), " must be passed a header, found ",
+              primitive.DebugString()));
         }
         drop->set_allocated_header(drop_rvalue.release_header_value());
         break;
@@ -577,23 +551,19 @@ gutil::StatusOr<Action> ExtractAction(
             primitive.fields().at("parameters");
         if (params.kind_case() != google::protobuf::Value::kListValue ||
             params.list_value().values_size() < 1) {
-          return absl::Status(
-              absl::StatusCode::kInvalidArgument,
-              absl::StrCat("hash statement in action ",
-                           pdpi_action.preamble().name(),
-                           " must at least specifiy target field, found ",
-                           primitive.DebugString()));
+          return absl::InvalidArgumentError(absl::StrCat(
+              "hash statement in action ", pdpi_action.preamble().name(),
+              " must at least specifiy target field, found ",
+              primitive.DebugString()));
         }
 
         ASSIGN_OR_RETURN(
             LValue hash_lvalue,
             ExtractLValue(params.list_value().values(0), parameter_map));
         if (hash_lvalue.lvalue_case() != LValue::kFieldValue) {
-          return absl::Status(absl::StatusCode::kInvalidArgument,
-                              absl::StrCat("Hash statement in action ",
-                                           pdpi_action.preamble().name(),
-                                           " must target a field, found ",
-                                           primitive.DebugString()));
+          return absl::InvalidArgumentError(absl::StrCat(
+              "Hash statement in action ", pdpi_action.preamble().name(),
+              " must target a field, found ", primitive.DebugString()));
         }
         hash->set_allocated_field(hash_lvalue.release_field_value());
         break;
@@ -603,20 +573,17 @@ gutil::StatusOr<Action> ExtractAction(
         break;
       }
       default:
-        return absl::Status(absl::StatusCode::kUnimplemented,
-                            absl::StrCat("Unsupported statement in action ",
-                                         pdpi_action.preamble().name(),
-                                         ", found ", primitive.DebugString()));
+        return absl::UnimplementedError(absl::StrCat(
+            "Unsupported statement in action ", pdpi_action.preamble().name(),
+            ", found ", primitive.DebugString()));
     }
 
     // Parse source_info struct into its own protobuf.
     // Applies to all types of statements.
     if (primitive.fields().count("source_info") != 1) {
-      return absl::Status(
-          absl::StatusCode::kInvalidArgument,
-          absl::StrCat("Statement in action ", pdpi_action.preamble().name(),
-                       " does not have source_info, found ",
-                       primitive.DebugString()));
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Statement in action ", pdpi_action.preamble().name(),
+          " does not have source_info, found ", primitive.DebugString()));
     }
 
     ASSIGN_OR_RETURN(
@@ -648,30 +615,27 @@ gutil::StatusOr<Table> ExtractTable(
       table_impl->set_action_selector_type(TableImplementation::INDIRECT_WS);
       break;
     default:
-      return absl::Status(absl::StatusCode::kUnimplemented,
-                          absl::StrCat("Unsupported action selector type in ",
-                                       bmv2_table.DebugString()));
+      return absl::UnimplementedError(absl::StrCat(
+          "Unsupported action selector type in ", bmv2_table.DebugString()));
   }
 
   // Look up the default action by its bmv2 json id.
   int default_action_id = bmv2_table.default_entry().action_id();
   if (actions.count(default_action_id) != 1) {
-    return absl::Status(absl::StatusCode::kInvalidArgument,
-                        absl::StrCat("Table ", pdpi_table.preamble().name(),
-                                     " has unknown default action id ",
-                                     bmv2_table.default_entry().action_id()));
+    return absl::InvalidArgumentError(
+        absl::StrCat("Table ", pdpi_table.preamble().name(),
+                     " has unknown default action id ",
+                     bmv2_table.default_entry().action_id()));
   }
-  Action default_action = actions.at(default_action_id);
+  const Action &default_action = actions.at(default_action_id);
 
   // Make sure default action arguments are consistent with its defined
   // parameters count.
-  if (default_action.action_implementation().parameters_size() !=
+  if (default_action.action_implementation().parameter_to_bitwidth_size() !=
       bmv2_table.default_entry().action_data_size()) {
-    return absl::Status(
-        absl::StatusCode::kInvalidArgument,
-        absl::StrCat(
-            "Table ", pdpi_table.preamble().name(),
-            " passes the wrong number of arguments to its default action"));
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Table ", pdpi_table.preamble().name(),
+        " passes the wrong number of arguments to its default action"));
   }
 
   // Extract default entry from bmv2 json.
@@ -683,7 +647,8 @@ gutil::StatusOr<Table> ExtractTable(
   // Set which flows are next for each possible action match in this table.
   for (const auto &[action_name, next_flow] : bmv2_table.next_tables()) {
     if (!next_flow.empty()) {
-      table_impl->mutable_next_flows()->insert({action_name, next_flow});
+      table_impl->mutable_action_to_next_flow()->insert(
+          {action_name, next_flow});
     }
   }
 
@@ -739,6 +704,8 @@ gutil::StatusOr<P4Program> Bmv2AndP4infoToIr(const bmv2::P4Program &bmv2,
         const bmv2::VariableDefinition &bmv2_parameter =
             bmv2_action.runtime_data(i);
 
+        // Bmv2 parameters ids start from 1 and are incremented in order
+        // of definition.
         p4::config::v1::Action::Param *pdpi_parameter =
             (*params_by_id)[i + 1].mutable_param();
         pdpi_parameter->set_id(i + 1);
@@ -787,6 +754,8 @@ gutil::StatusOr<P4Program> Bmv2AndP4infoToIr(const bmv2::P4Program &bmv2,
         for (int i = 0; i < bmv2_table.key_size(); i++) {
           const bmv2::TableKey &key = bmv2_table.key(i);
 
+          // Match field ids start at 1 and are incremented by 1 in order
+          // of definition.
           p4::config::v1::MatchField *match_field =
               (*match_fields_by_id)[i + 1].mutable_match_field();
           match_field->set_id(i + 1);
@@ -797,8 +766,7 @@ gutil::StatusOr<P4Program> Bmv2AndP4infoToIr(const bmv2::P4Program &bmv2,
               break;
             }
             default:
-              return absl::Status(
-                  absl::StatusCode::kUnimplemented,
+              return absl::UnimplementedError(
                   absl::StrCat("Unsupported match type ", key.DebugString(),
                                " in table", table_name));
           }
@@ -836,8 +804,7 @@ gutil::StatusOr<P4Program> Bmv2AndP4infoToIr(const bmv2::P4Program &bmv2,
 
   // Find init_table.
   if (bmv2.pipelines_size() < 1) {
-    return absl::Status(absl::StatusCode::kInvalidArgument,
-                        "BMV2 file contains no pipelines!");
+    return absl::InvalidArgumentError("BMV2 file contains no pipelines!");
   }
   output.set_initial_flow(bmv2.pipelines(0).init_table());
   return output;

--- a/p4_symbolic/ir/ir.cc
+++ b/p4_symbolic/ir/ir.cc
@@ -559,6 +559,13 @@ gutil::StatusOr<Table> ExtractTable(
   table_impl->mutable_default_action_parameters()->CopyFrom(
       bmv2_table.default_entry().action_data());
 
+  // Set which flows are next for each possible action match in this table.
+  for (const auto &[action_name, next_flow] : bmv2_table.next_tables()) {
+    if (!next_flow.empty()) {
+      table_impl->mutable_next_flows()->insert({action_name, next_flow});
+    }
+  }
+
   return output;
 }
 

--- a/p4_symbolic/ir/ir.cc
+++ b/p4_symbolic/ir/ir.cc
@@ -644,11 +644,11 @@ gutil::StatusOr<Table> ExtractTable(
   table_impl->mutable_default_action_parameters()->CopyFrom(
       bmv2_table.default_entry().action_data());
 
-  // Set which flows are next for each possible action match in this table.
-  for (const auto &[action_name, next_flow] : bmv2_table.next_tables()) {
-    if (!next_flow.empty()) {
-      table_impl->mutable_action_to_next_flow()->insert(
-          {action_name, next_flow});
+  // Set which controls are next for each possible action match in this table.
+  for (const auto &[action_name, next_control] : bmv2_table.next_tables()) {
+    if (!next_control.empty()) {
+      table_impl->mutable_action_to_next_control()->insert(
+          {action_name, next_control});
     }
   }
 
@@ -806,7 +806,7 @@ gutil::StatusOr<P4Program> Bmv2AndP4infoToIr(const bmv2::P4Program &bmv2,
   if (bmv2.pipelines_size() < 1) {
     return absl::InvalidArgumentError("BMV2 file contains no pipelines!");
   }
-  output.set_initial_flow(bmv2.pipelines(0).init_table());
+  output.set_initial_control(bmv2.pipelines(0).init_table());
   return output;
 }
 

--- a/p4_symbolic/ir/ir.proto
+++ b/p4_symbolic/ir/ir.proto
@@ -75,11 +75,11 @@ message Action {
 
 // Action implementation details.
 message ActionImplementation {
-  // Type of all variables used in action_body.
-  // Maps a variable name to its bitwidth.
-  map<string, int32> variables = 1;
+  // Type of all action parameters.
+  // Maps a parameter name to its bitwidth.
+  map<string, int32> parameters = 2;
   // List of statements in action body in sequence.
-  repeated Statement action_body = 2;
+  repeated Statement action_body = 3;
 }
 
 // Overall table structure, combining definition with implementation.
@@ -100,6 +100,12 @@ message TableImplementation {
 
   // Table type with respect to action selection.
   ActionSelectorType action_selector_type = 1;
+
+  // Default action name (e.g. when no other entry is matched).
+  string default_action = 2;
+
+  // Hexstring values passed to default action as parameters.
+  repeated string default_action_parameters = 3;
 }
 
 // An abstract p4 statement corresponding to a top level operation within

--- a/p4_symbolic/ir/ir.proto
+++ b/p4_symbolic/ir/ir.proto
@@ -115,6 +115,11 @@ message TableImplementation {
 
   // Hexstring values passed to default action as parameters.
   repeated string default_action_parameters = 3;
+
+  // Maps every action used by this table (by name) to the next control block
+  // to be taken (also by name) if that action was matched.
+  // if an action is not in this map, then that action is the end of the flow.
+  map<string, string> next_flows = 4;
 }
 
 // A conditional statement.
@@ -123,7 +128,7 @@ message TableImplementation {
 // entry point in a workflow, or it may be called from other places using its
 // name.
 // Note that bmv2 accepts using a conditional name in fields that typically
-// expect a table name, such as the initial_table, or next_table attributes.
+// expect a table name, such as the initial_flow, or next_flow attributes.
 message Conditional {
   // The name is unique among conditionals AND tables.
   string name = 1;

--- a/p4_symbolic/ir/ir.proto
+++ b/p4_symbolic/ir/ir.proto
@@ -48,8 +48,17 @@ message P4Program {
   map<string, Action> actions = 2;
   // Table definitions and implementations, keyed by qualified table name.
   map<string, Table> tables = 3;
-  // The name of the initial table.
-  string initial_table = 6;
+  // Conditionals, keyed by their name.
+  map<string, Conditional> conditionals = 4;
+
+  // TODO(babman): If needed in the future, action calls can be added here, for
+  // action calls that are not wrapped in other control constructs.
+  // https://github.com/p4lang/behavioral-model/blob/master/docs/JSON_format.md#pipelines
+
+  // The name of the initial control flow construct, typically
+  // this is a table, but it might be a conditional (or an action call if
+  // action_calls mentioned above get supported).
+  string initial_flow = 6;
 }
 
 // A header type definition.
@@ -106,6 +115,22 @@ message TableImplementation {
 
   // Hexstring values passed to default action as parameters.
   repeated string default_action_parameters = 3;
+}
+
+// A conditional statement.
+// In p4 and BMV2 JSON format, a condition is not part of an action body.
+// It is a part of the top level control block. A conditional may be the first
+// entry point in a workflow, or it may be called from other places using its
+// name.
+// Note that bmv2 accepts using a conditional name in fields that typically
+// expect a table name, such as the initial_table, or next_table attributes.
+message Conditional {
+  // The name is unique among conditionals AND tables.
+  string name = 1;
+  RValue condition = 2;
+  // If a branch does not exist or is empty, this will be the empty string.
+  string if_branch = 3;
+  string else_branch = 4;
 }
 
 // An abstract p4 statement corresponding to a top level operation within
@@ -180,8 +205,8 @@ message Variable {
 // An abstract RExpression.
 message RExpression {
   oneof expression {
-    BinaryExpression simple_binary_expression = 1;
-    UnaryExpression simple_unary_expression = 2;
+    BinaryExpression binary_expression = 1;
+    UnaryExpression unary_expression = 2;
     TernaryExpression ternary_expression = 3;
   }
 }

--- a/p4_symbolic/ir/ir.proto
+++ b/p4_symbolic/ir/ir.proto
@@ -145,6 +145,9 @@ message Statement {
   // Various statement concrete types.
   oneof statement {
     AssignmentStatement assignment = 2;
+    DropStatement drop = 3;
+    CloneStatement clone = 4;
+    HashStatement hash = 5;
   }
 }
 
@@ -155,9 +158,35 @@ message AssignmentStatement {
   RValue right = 2;
 }
 
+// A statement marking the packet (by its header or metadata)
+// to be dropped.
+message DropStatement {
+  HeaderValue header = 1;
+}
+
+// A statement cloning the packet, corresponds to `clone3`.
+message CloneStatement {
+  // We do not care about the arguments to clone3:
+  // 1. We only support one version of cloning: ingree to egress
+  // 2. The session id is not know at parsing time.
+  // 3. We do not support clone calls preserving custom fields.
+}
+
+// Hashing statement to modify a selected field based on a hash calculation.
+// Corresponds to calls to `hash`.
+message HashStatement {
+  // The field where the hash is stored.
+  FieldValue field = 1;
+  // We do not care about the remaining arguments (Hash algorithm,
+  // range size, base value, and input fields).
+  // These should perhaps be added in the future if the hash symbolic modeling
+  // becomes more sophisticated.
+}
+
 // The structure of an abstract RValue.
 message RValue {
   oneof rvalue {
+    HeaderValue header_value = 1;
     FieldValue field_value = 2;
     HexstrValue hexstr_value = 3;
     BoolValue bool_value = 4;
@@ -173,6 +202,13 @@ message LValue {
     FieldValue field_value = 1;
     Variable variable_value = 2;
   }
+}
+
+// A header accessed by name.
+// This is used in operations and statements that refer to the whole packet.
+// For example, in mark_to_drop(<header>).
+message HeaderValue {
+  string header_name = 1;
 }
 
 // A header field accessed statically.
@@ -213,6 +249,7 @@ message RExpression {
     BinaryExpression binary_expression = 1;
     UnaryExpression unary_expression = 2;
     TernaryExpression ternary_expression = 3;
+    BuiltinExpression builtin_expression = 4;
   }
 }
 
@@ -260,4 +297,15 @@ message TernaryExpression {
   RValue condition = 1;
   RValue left = 2;
   RValue right = 3;
+}
+
+// Calls tp built in functions (e.g. b2d).
+message BuiltinExpression {
+  // Supported built in functions.
+  enum Function {
+    BOOL_TO_DATA = 0;
+    DATA_TO_BOOL = 1;
+  }
+  Function function = 1;
+  repeated RValue arguments = 2;
 }

--- a/p4_symbolic/ir/ir.proto
+++ b/p4_symbolic/ir/ir.proto
@@ -234,8 +234,8 @@ message BinaryExpression {
   }
 
   Operation operation = 1;
-  RExpression left = 2;
-  RExpression right = 3;
+  RValue left = 2;
+  RValue right = 3;
 }
 
 // Arithmetic and boolean unary operations.
@@ -247,12 +247,12 @@ message UnaryExpression {
   }
 
   Operation operation = 1;
-  RExpression operand = 2;
+  RValue operand = 2;
 }
 
 // Ternary condition on the form <condition> ? <left> : <right>.
 message TernaryExpression {
-  RExpression condition = 1;
-  RExpression left = 2;
-  RExpression right = 3;
+  RValue condition = 1;
+  RValue left = 2;
+  RValue right = 3;
 }

--- a/p4_symbolic/ir/ir.proto
+++ b/p4_symbolic/ir/ir.proto
@@ -86,7 +86,7 @@ message Action {
 message ActionImplementation {
   // Type of all action parameters.
   // Maps a parameter name to its bitwidth.
-  map<string, int32> parameters = 2;
+  map<string, int32> parameter_to_bitwidth = 2;
   // List of statements in action body in sequence.
   repeated Statement action_body = 3;
 }
@@ -110,16 +110,18 @@ message TableImplementation {
   // Table type with respect to action selection.
   ActionSelectorType action_selector_type = 1;
 
-  // Default action name (e.g. when no other entry is matched).
+  // Default action name. This action is called with the default parameters
+  // below, when none of this table's entries are matched on.
   string default_action = 2;
 
   // Hexstring values passed to default action as parameters.
   repeated string default_action_parameters = 3;
 
-  // Maps every action used by this table (by name) to the next control block
-  // to be taken (also by name) if that action was matched.
-  // if an action is not in this map, then that action is the end of the flow.
-  map<string, string> next_flows = 4;
+  // Maps every action used by this table (by name) to the next control flow
+  // construct to be taken (also by name) if that action was matched.
+  // if an action is not in this map, or is mapped to the empty string, then
+  // that action is at the end of the flow.
+  map<string, string> action_to_next_flow = 4;
 }
 
 // A conditional statement.

--- a/p4_symbolic/ir/ir.proto
+++ b/p4_symbolic/ir/ir.proto
@@ -55,10 +55,10 @@ message P4Program {
   // action calls that are not wrapped in other control constructs.
   // https://github.com/p4lang/behavioral-model/blob/master/docs/JSON_format.md#pipelines
 
-  // The name of the initial control flow construct, typically
+  // The name of the initial control construct, typically
   // this is a table, but it might be a conditional (or an action call if
   // action_calls mentioned above get supported).
-  string initial_flow = 6;
+  string initial_control = 6;
 }
 
 // A header type definition.
@@ -117,11 +117,11 @@ message TableImplementation {
   // Hexstring values passed to default action as parameters.
   repeated string default_action_parameters = 3;
 
-  // Maps every action used by this table (by name) to the next control flow
+  // Maps every action used by this table (by name) to the next control
   // construct to be taken (also by name) if that action was matched.
   // if an action is not in this map, or is mapped to the empty string, then
   // that action is at the end of the flow.
-  map<string, string> action_to_next_flow = 4;
+  map<string, string> action_to_next_control = 4;
 }
 
 // A conditional statement.
@@ -130,7 +130,8 @@ message TableImplementation {
 // entry point in a workflow, or it may be called from other places using its
 // name.
 // Note that bmv2 accepts using a conditional name in fields that typically
-// expect a table name, such as the initial_flow, or next_flow attributes.
+// expect a table name, such as the initial_control, or next_controls
+// attributes.
 message Conditional {
   // The name is unique among conditionals AND tables.
   string name = 1;

--- a/p4_symbolic/symbolic/action.cc
+++ b/p4_symbolic/symbolic/action.cc
@@ -32,10 +32,9 @@ gutil::StatusOr<SymbolicPerPacketState> EvaluateStatement(
                                          context);
 
     default:
-      return absl::Status(absl::StatusCode::kUnimplemented,
-                          absl::StrCat("Action ", context->action_name,
-                                       " contains unsupported statement ",
-                                       statement.DebugString()));
+      return absl::UnimplementedError(absl::StrCat(
+          "Action ", context->action_name, " contains unsupported statement ",
+          statement.DebugString()));
   }
 }
 
@@ -65,10 +64,9 @@ gutil::StatusOr<SymbolicPerPacketState> EvaluateAssignmentStatement(
       std::string field_name = absl::StrFormat(
           "%s.%s", field_value.header_name(), field_value.field_name());
       if (modified_state.metadata.count(field_name) != 1) {
-        return absl::Status(absl::StatusCode::kUnimplemented,
-                            absl::StrCat("Action ", context->action_name,
-                                         " refers to unknown header field ",
-                                         field_value.DebugString()));
+        return absl::UnimplementedError(absl::StrCat(
+            "Action ", context->action_name, " refers to unknown header field ",
+            field_value.DebugString()));
       }
 
       modified_state.metadata.at(field_name) = right;
@@ -82,10 +80,9 @@ gutil::StatusOr<SymbolicPerPacketState> EvaluateAssignmentStatement(
     }
 
     default:
-      return absl::Status(absl::StatusCode::kUnimplemented,
-                          absl::StrCat("Action ", context->action_name,
-                                       " contains unsupported LValue ",
-                                       assignment.left().DebugString()));
+      return absl::UnimplementedError(absl::StrCat(
+          "Action ", context->action_name, " contains unsupported LValue ",
+          assignment.left().DebugString()));
   }
 }
 
@@ -102,8 +99,7 @@ gutil::StatusOr<z3::expr> EvaluateRValue(const ir::RValue &rvalue,
       return EvaluateVariable(rvalue.variable_value(), state, context);
 
     default:
-      return absl::Status(
-          absl::StatusCode::kUnimplemented,
+      return absl::UnimplementedError(
           absl::StrCat("Action ", context->action_name,
                        " contains unsupported RValue ", rvalue.DebugString()));
   }
@@ -116,10 +112,9 @@ gutil::StatusOr<z3::expr> EvaluateFieldValue(
   std::string field_name = absl::StrFormat("%s.%s", field_value.header_name(),
                                            field_value.field_name());
   if (state.metadata.count(field_name) != 1) {
-    return absl::Status(absl::StatusCode::kUnimplemented,
-                        absl::StrCat("Action ", context->action_name,
-                                     " refers to unknown header field ",
-                                     field_value.DebugString()));
+    return absl::UnimplementedError(absl::StrCat(
+        "Action ", context->action_name, " refers to unknown header field ",
+        field_value.DebugString()));
   }
 
   return state.metadata.at(field_name);
@@ -131,8 +126,7 @@ gutil::StatusOr<z3::expr> EvaluateVariable(const ir::Variable &variable,
                                            ActionContext *context) {
   std::string variable_name = variable.name();
   if (context->scope.count(variable_name) != 1) {
-    return absl::Status(
-        absl::StatusCode::kInvalidArgument,
+    return absl::InvalidArgumentError(
         absl::StrCat("Action ", context->action_name,
                      " refers to undefined variable ", variable_name));
   }
@@ -156,8 +150,7 @@ gutil::StatusOr<SymbolicPerPacketState> EvaluateAction(
   // Add action parameters to scope.
   const auto &parameters = action.action_definition().params_by_id();
   if (static_cast<int>(parameters.size()) != args.size()) {
-    return absl::Status(
-        absl::StatusCode::kInvalidArgument,
+    return absl::InvalidArgumentError(
         absl::StrCat("Action ", action.action_definition().preamble().name(),
                      " called with incompatible number of parameters"));
   }
@@ -182,8 +175,7 @@ gutil::StatusOr<SymbolicPerPacketState> EvaluateAction(
 
     // Error if parameter name is not found in entries.
     if (!found_parameter) {
-      return absl::Status(
-          absl::StatusCode::kInvalidArgument,
+      return absl::InvalidArgumentError(
           absl::StrCat("Action ", action.action_definition().preamble().name(),
                        " called without passing parameter ", parameter_name));
     }

--- a/p4_symbolic/symbolic/util.cc
+++ b/p4_symbolic/symbolic/util.cc
@@ -215,8 +215,7 @@ gutil::StatusOr<z3::expr> IrValueToZ3Expr(const pdpi::IrValue &value) {
       return Z3Context().int_val(static_cast<int>(bytes.at(1)));
     }
     default:
-      return absl::Status(
-          absl::StatusCode::kUnimplemented,
+      return absl::UnimplementedError(
           absl::StrCat("Found unsupported value type ", value.DebugString()));
   }
 

--- a/p4_symbolic/util/io.cc
+++ b/p4_symbolic/util/io.cc
@@ -31,12 +31,11 @@ absl::Status ErrorNoToAbsl(const char *operation, const std::string &path) {
   switch (errno) {
     case EACCES:
     case ENOENT:
-      return absl::Status(absl::StatusCode::kNotFound,
-                          absl::StrFormat("%s: %s", strerror(errno), path));
+      return absl::NotFoundError(
+          absl::StrFormat("%s: %s", strerror(errno), path));
     default:
-      return absl::Status(absl::StatusCode::kUnknown,
-                          absl::StrFormat("Cannot %s file %s, errno = %d",
-                                          operation, path, errno));
+      return absl::UnknownError(absl::StrFormat("Cannot %s file %s, errno = %d",
+                                                operation, path, errno));
   }
 }
 


### PR DESCRIPTION
Added support for the following features:
1. Auto-generated tables and actions by p4c that do not appear in p4info.
2. Conditionals.
3. Parse the "next_tables" attribute specifying the next flow control to execute after a table match.
4. Header values (i.e. referring to a header by name).
5. Hexstring, bool, and string literals.
6. Unary (~, not), binary (+, -, *, ==, !=, <<, >>, <, <=, >, >=, &, |, ^, and, or), and ternary expressions (<condition> ? <true_val> : <false_val>).
7. Builtin function call expressions (b2d, d2b).
8. Builtin action call statements (mark_to_drop, hash, clone3).
9. Support strangely nested expressions, where the JSON file may contain several layers of useless abstract expressions surrounding the actual expression object (similar to having many useless parenthesis around an expression).

Hash only parses the target field, clone3 ignores all arguments.

With these supported features, our tool can parse all our p4-sample programs to IR:
* Added golden test files for all p4-sample programs that include output IR and parsed P4RT table entries.
* Added missing required annotations to p4-sample programs so that they are accepted by p4-pdpi.
* Encode table entries for p4-samples/ipv4-routing in P4RT protobuf format.

Finally, this also contains a few clean ups, and updates to existing golden files to reflect these clean ups:
* Renamed "initial_table" to "initial_flow" in IR proto.
* Various string to enum map lookup functions used in p4_symbolic/ir/ir.cc now return StatusOr and use it to signal unsupported strings, instead of defining an explicit "unsupported_<type>" case in their respective enum and returning that.