### PR TITLE
Add vrf-routing sample program

### DIFF
--- a/p4-samples/vrf-routing/.gitignore
+++ b/p4-samples/vrf-routing/.gitignore
@@ -1,0 +1,5 @@
+*.json
+*.p4i
+*.log
+*.pid
+vrf.pb.txt

--- a/p4-samples/vrf-routing/Makefile
+++ b/p4-samples/vrf-routing/Makefile
@@ -1,0 +1,44 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHELL := /bin/bash
+
+run: build simple_switch control_plane packets
+
+#
+# Control Plane
+# insert entries into p4 tables
+#
+CONTROL_PLANE_COMMANDS=$$(cat entries.txt)
+
+#
+# Sending Test Packets
+#
+define PACKETS =
+p = Ether()/IP(dst="20.20.0.1")/UDP()\n\
+sendp(p, iface="veth1")\n\
+p = Ether()/IP(dst="20.20.0.2")/UDP()\n\
+sendp(p, iface="veth1")\n\
+# this should show up once \n\
+p = Ether()/IP(dst="10.10.0.1")/UDP()\n\
+sendp(p, iface="veth3")\n\
+# this should not show up \n\
+p = Ether()/IP(dst="10.10.0.2")/UDP()\n\
+sendp(p, iface="veth1")\n
+endef
+
+VETH_PAIRS_COUNT := 2
+
+# include main Makefile with rules
+include ../Makefile

--- a/p4-samples/vrf-routing/entries.pb.txt
+++ b/p4-samples/vrf-routing/entries.pb.txt
@@ -1,0 +1,186 @@
+updates {
+  type: INSERT,
+  entity {
+    table_entry {
+      table_id: 37105383
+      match {
+        field_id: 1,
+        ternary {
+          value: "\000!\001\000",
+          mask: "\011!\011\011"
+        }
+      }
+      action {
+        action {
+          action_id: 24959910
+          params {
+            param_id: 1
+            value: "\02"
+          }
+        }
+      }
+      priority: 2
+    }
+  }
+}
+updates {
+  type: INSERT,
+  entity {
+    table_entry {
+      table_id: 37105383
+      match {
+        field_id: 1,
+        ternary {
+          value: "!!\000\000",
+          mask: "!!\011\011"
+        }
+      }
+      action {
+        action {
+          action_id: 24959910
+          params {
+            param_id: 1
+            value: "\01"
+          }
+        }
+      }
+      priority: 1
+    }
+  }
+}
+updates {
+  type: INSERT,
+  entity {
+    table_entry {
+      table_id: 45604648
+      match {
+        field_id: 1,
+        lpm {
+          value: "\n\n\000\000",
+          prefix_len: 16
+        }
+      }
+      match {
+        field_id: 2,
+        exact {
+          value: "\01"
+        }
+      }
+      action {
+        action {
+          action_id: 28792405
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\000"
+          }
+          params {
+            param_id: 2
+            value: "\00"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT,
+  entity {
+    table_entry {
+      table_id: 45604648
+      match {
+        field_id: 1,
+        lpm {
+          value: "\n\n\000\000",
+          prefix_len: 32
+        }
+      }
+      match {
+        field_id: 2,
+        exact {
+          value: "\01"
+        }
+      }
+      action {
+        action {
+          action_id: 28792405
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\000"
+          }
+          params {
+            param_id: 2
+            value: "\01"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT,
+  entity {
+    table_entry {
+      table_id: 45604648
+      match {
+        field_id: 1,
+        lpm {
+          value: "\n\000\000\000",
+          prefix_len: 8
+        }
+      }
+      match {
+        field_id: 2,
+        exact {
+          value: "\01"
+        }
+      }
+      action {
+        action {
+          action_id: 28792405
+          params {
+            param_id: 1
+            value: "\000\000\000\000\000\n"
+          }
+          params {
+            param_id: 2
+            value: "\01"
+          }
+        }
+      }
+    }
+  }
+}
+updates {
+  type: INSERT,
+  entity {
+    table_entry {
+      table_id: 45604648
+      match {
+        field_id: 1,
+        lpm {
+          value: "\024\024\000\000",
+          prefix_len: 16
+        }
+      }
+      match {
+        field_id: 2,
+        exact {
+          value: "\02"
+        }
+      }
+      action {
+        action {
+          action_id: 28792405
+          params {
+            param_id: 1
+            value: "\026\000\000\000\000\026"
+          }
+          params {
+            param_id: 2
+            value: "\01"
+          }
+        }
+      }
+    }
+  }
+}

--- a/p4-samples/vrf-routing/entries.pb.txt
+++ b/p4-samples/vrf-routing/entries.pb.txt
@@ -2,7 +2,7 @@ updates {
   type: INSERT,
   entity {
     table_entry {
-      table_id: 37105383
+      table_id: 37541331
       match {
         field_id: 1,
         ternary {
@@ -12,7 +12,7 @@ updates {
       }
       action {
         action {
-          action_id: 24959910
+          action_id: 26074559
           params {
             param_id: 1
             value: "\02"
@@ -27,7 +27,7 @@ updates {
   type: INSERT,
   entity {
     table_entry {
-      table_id: 37105383
+      table_id: 37541331
       match {
         field_id: 1,
         ternary {
@@ -37,7 +37,7 @@ updates {
       }
       action {
         action {
-          action_id: 24959910
+          action_id: 26074559
           params {
             param_id: 1
             value: "\01"
@@ -52,7 +52,7 @@ updates {
   type: INSERT,
   entity {
     table_entry {
-      table_id: 45604648
+      table_id: 44809600
       match {
         field_id: 1,
         lpm {
@@ -68,7 +68,7 @@ updates {
       }
       action {
         action {
-          action_id: 28792405
+          action_id: 27807574
           params {
             param_id: 1
             value: "\000\000\000\000\000\000"
@@ -86,7 +86,7 @@ updates {
   type: INSERT,
   entity {
     table_entry {
-      table_id: 45604648
+      table_id: 44809600
       match {
         field_id: 1,
         lpm {
@@ -102,7 +102,7 @@ updates {
       }
       action {
         action {
-          action_id: 28792405
+          action_id: 27807574
           params {
             param_id: 1
             value: "\000\000\000\000\000\000"
@@ -120,7 +120,7 @@ updates {
   type: INSERT,
   entity {
     table_entry {
-      table_id: 45604648
+      table_id: 44809600
       match {
         field_id: 1,
         lpm {
@@ -136,7 +136,7 @@ updates {
       }
       action {
         action {
-          action_id: 28792405
+          action_id: 27807574
           params {
             param_id: 1
             value: "\000\000\000\000\000\n"
@@ -154,7 +154,7 @@ updates {
   type: INSERT,
   entity {
     table_entry {
-      table_id: 45604648
+      table_id: 44809600
       match {
         field_id: 1,
         lpm {
@@ -170,7 +170,7 @@ updates {
       }
       action {
         action {
-          action_id: 28792405
+          action_id: 27807574
           params {
             param_id: 1
             value: "\026\000\000\000\000\026"

--- a/p4-samples/vrf-routing/entries.txt
+++ b/p4-samples/vrf-routing/entries.txt
@@ -1,0 +1,6 @@
+table_add set_vrf_table set_vrf 0.33.1.0&&&11.33.11.11 => 2 2
+table_add set_vrf_table set_vrf 33.33.0.0&&&33.33.11.11 => 1 1
+table_add ipv4_lpm_table ipv4_forward 10.10.0.0/16 1 => 00:00:00:00:00:00 0
+table_add ipv4_lpm_table ipv4_forward 10.10.0.0/32 1 => 00:00:00:00:00:00 1
+table_add ipv4_lpm_table ipv4_forward 10.0.0.0/8 1 => 00:00:00:00:00:10 1
+table_add ipv4_lpm_table ipv4_forward 20.20.0.0/16 2 => 22:00:00:00:00:22 1

--- a/p4-samples/vrf-routing/test.sh
+++ b/p4-samples/vrf-routing/test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+make build && cd ../../ && bazel build //p4_symbolic:main && ./bazel-bin/p4_symbolic/main --bmv2=p4-samples/vrf-routing/vrf.json --p4info=p4-samples/vrf-routing/vrf.pb.txt --entries=p4-samples/vrf-routing/entries.pb.txt --nohardcoded_parser

--- a/p4-samples/vrf-routing/vrf.p4
+++ b/p4-samples/vrf-routing/vrf.p4
@@ -18,201 +18,150 @@
 
 const bit<16> TYPE_IPV4 = 0x800;
 
-/*************************************************************************
-*********************** H E A D E R S  ***********************************
-*************************************************************************/
-
 typedef bit<9>  egressSpec_t;
 typedef bit<48> macAddr_t;
 typedef bit<32> ip4Addr_t;
 
 header ethernet_t {
-    macAddr_t dstAddr;
-    macAddr_t srcAddr;
-    bit<16>   etherType;
+  macAddr_t dstAddr;
+  macAddr_t srcAddr;
+  bit<16> etherType;
 }
-
 header ipv4_t {
-    bit<4>    version;
-    bit<4>    ihl;
-    bit<8>    diffserv;
-    bit<16>   totalLen;
-    bit<16>   identification;
-    bit<3>    flags;
-    bit<13>   fragOffset;
-    bit<8>    ttl;
-    bit<8>    protocol;
-    bit<16>   hdrChecksum;
-    ip4Addr_t srcAddr;
-    ip4Addr_t dstAddr;
+  bit<4> version;
+  bit<4> ihl;
+  bit<8> diffserv;
+  bit<16> totalLen;
+  bit<16> identification;
+  bit<3> flags;
+  bit<13> fragOffset;
+  bit<8> ttl;
+  bit<8> protocol;
+  bit<16> hdrChecksum;
+  ip4Addr_t srcAddr;
+  ip4Addr_t dstAddr;
 }
-
-struct local_metadata_t {
-    bit<10> vrf;
-    bool vrf_is_valid;
-}
-
 struct headers {
-    ethernet_t   ethernet;
-    ipv4_t       ipv4;
+  ethernet_t ethernet;
+  ipv4_t ipv4;
+}
+struct local_metadata_t {
+  bit<10> vrf;
+  bool vrf_is_valid;
 }
 
-/*************************************************************************
-*********************** P A R S E R  ***********************************
-*************************************************************************/
-
-parser MyParser(packet_in packet,
-                out headers hdr,
+parser MyParser(packet_in packet, out headers hdr,
                 inout local_metadata_t local_metadata,
                 inout standard_metadata_t standard_metadata) {
+  state start {
+    transition parse_ethernet;
+  }
 
-    state start {
-        transition parse_ethernet;
+  state parse_ethernet {
+    packet.extract(hdr.ethernet);
+    transition select(hdr.ethernet.etherType) {
+      TYPE_IPV4: parse_ipv4;
+      default: accept;
     }
+  }
 
-    state parse_ethernet {
-        packet.extract(hdr.ethernet);
-        transition select(hdr.ethernet.etherType) {
-            TYPE_IPV4: parse_ipv4;
-            default: accept;
-        }
-    }
-
-    state parse_ipv4 {
-        packet.extract(hdr.ipv4);
-        transition accept;
-    }
-
+  state parse_ipv4 {
+    packet.extract(hdr.ipv4);
+    transition accept;
+  }
 }
 
-/*************************************************************************
-************   C H E C K S U M    V E R I F I C A T I O N   *************
-*************************************************************************/
-
-control MyVerifyChecksum(inout headers hdr, inout local_metadata_t local_metadata) {   
-    apply {  }
-}
-
-
-/*************************************************************************
-**************  I N G R E S S   P R O C E S S I N G   *******************
-*************************************************************************/
-
+// Ingress processing:
+// First set vrf by matching on ipv4.srcAddr,
+// then match on vrf and ipv4.dstAddr to route.
 control MyIngress(inout headers hdr,
                   inout local_metadata_t local_metadata,
                   inout standard_metadata_t standard_metadata) {
+  // NoAction: 21257015
+  // 25652968
+  action drop() {
+    mark_to_drop(standard_metadata);
+  }
 
-    // NoAction: 21257015
-    // 25652968
-    action drop() {
-        mark_to_drop(standard_metadata);
-    }
+  // 24959910
+  action set_vrf(bit<10> vrf) {
+    local_metadata.vrf = vrf;
+    local_metadata.vrf_is_valid = true;
+  }
 
-    // 24959910
-    action set_vrf(bit<10> vrf) {
-      local_metadata.vrf = vrf;
-      local_metadata.vrf_is_valid = true;
-    }
+  // 28792405
+  action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
+    standard_metadata.egress_spec = port;
+    hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
+    hdr.ethernet.dstAddr = dstAddr;
+    hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
+  }
 
-    // 28792405
-    action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
-        standard_metadata.egress_spec = port;
-        hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
-        hdr.ethernet.dstAddr = dstAddr;
-        hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
+  // 37105383
+  table set_vrf_table {
+    key = {
+      hdr.ipv4.srcAddr: ternary @format(IPV4_ADDRESS);
     }
+    actions = {
+      @proto_id(1) set_vrf;
+      @proto_id(2) NoAction;
+    }
+    size = 1024;
+    default_action = NoAction;
+  }
 
-    // 37105383
-    table set_vrf_table {
-        key = {
-            hdr.ipv4.srcAddr: ternary @format(IPV4_ADDRESS);
-        }
-        actions = {
-            @proto_id(1) set_vrf;
-            @proto_id(2) NoAction;
-        }
-        size = 1024;
-        default_action = NoAction;
+  // 45604648
+  table ipv4_lpm_table {
+    key = {
+      hdr.ipv4.dstAddr: lpm @format(IPV4_ADDRESS);
+      local_metadata.vrf: exact;
     }
+    actions = {
+      @proto_id(1) ipv4_forward;
+      @proto_id(2) drop;
+    }
+    size = 1024;
+    default_action = drop();
+  }
 
-    // 45604648
-    table ipv4_lpm_table {
-        key = {
-            hdr.ipv4.dstAddr: lpm @format(IPV4_ADDRESS);
-            local_metadata.vrf: exact;
-        }
-        actions = {
-            @proto_id(1) ipv4_forward;
-            @proto_id(2) drop;
-        }
-        size = 1024;
-        default_action = drop();
-    }
-    
-    apply {
-        // vrf is not valid by default.
-        local_metadata.vrf_is_valid = false;
+  apply {
+    // vrf is not valid by default.
+    local_metadata.vrf_is_valid = false;
 
-        // Check that the packet is an ipv4 packet.
-        if (hdr.ipv4.isValid()) {
-            // Set a vrf.
-            set_vrf_table.apply();
-            if (local_metadata.vrf_is_valid) {
-              // If vrf was set, do lpm matching on dst to route.
-              ipv4_lpm_table.apply();
-            }   
-        }
+    // Check that the packet is an ipv4 packet.
+    if (hdr.ipv4.isValid()) {
+      // Set a vrf.
+      set_vrf_table.apply();
+      if (local_metadata.vrf_is_valid) {
+        // If vrf was set, do lpm matching on dst to route.
+        ipv4_lpm_table.apply();
+      }   
     }
+  }
 }
-
-/*************************************************************************
-****************  E G R E S S   P R O C E S S I N G   *******************
-*************************************************************************/
-
-control MyEgress(inout headers hdr,
-                 inout local_metadata_t local_metadata,
-                 inout standard_metadata_t standard_metadata) {
-    apply {  }
-}
-
-/*************************************************************************
-*************   C H E C K S U M    C O M P U T A T I O N   **************
-*************************************************************************/
-
-control MyComputeChecksum(inout headers  hdr, inout local_metadata_t local_metadata) {
-    apply {
-	      update_checksum(
-      	    hdr.ipv4.isValid(),
-            { hdr.ipv4.version,
-	            hdr.ipv4.ihl,
-              hdr.ipv4.diffserv,
-              hdr.ipv4.totalLen,
-              hdr.ipv4.identification,
-              hdr.ipv4.flags,
-              hdr.ipv4.fragOffset,
-              hdr.ipv4.ttl,
-              hdr.ipv4.protocol,
-              hdr.ipv4.srcAddr,
-              hdr.ipv4.dstAddr },
-            hdr.ipv4.hdrChecksum,
-            HashAlgorithm.csum16);
-    }
-}
-
-/*************************************************************************
-***********************  D E P A R S E R  *******************************
-*************************************************************************/
 
 control MyDeparser(packet_out packet, in headers hdr) {
-    apply {
-        packet.emit(hdr.ethernet);
-        packet.emit(hdr.ipv4);
-    }
+  apply {
+    packet.emit(hdr.ethernet);
+    packet.emit(hdr.ipv4);
+  }
 }
 
-/*************************************************************************
-***********************  S W I T C H  *******************************
-*************************************************************************/
+control MyEgress(inout headers hdr, inout local_metadata_t local_metadata,
+                 inout standard_metadata_t standard_metadata) {
+  apply {}
+}
+
+
+control MyComputeChecksum(inout headers hdr,
+                          inout local_metadata_t local_metadata) {
+  apply {}
+}
+
+control MyVerifyChecksum(inout headers hdr,
+                         inout local_metadata_t local_metadata) {   
+  apply {}
+}
 
 V1Switch(
 MyParser(),

--- a/p4-samples/vrf-routing/vrf.p4
+++ b/p4-samples/vrf-routing/vrf.p4
@@ -1,0 +1,224 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* -*- P4_16 -*- */
+#include <core.p4>
+#include <v1model.p4>
+
+const bit<16> TYPE_IPV4 = 0x800;
+
+/*************************************************************************
+*********************** H E A D E R S  ***********************************
+*************************************************************************/
+
+typedef bit<9>  egressSpec_t;
+typedef bit<48> macAddr_t;
+typedef bit<32> ip4Addr_t;
+
+header ethernet_t {
+    macAddr_t dstAddr;
+    macAddr_t srcAddr;
+    bit<16>   etherType;
+}
+
+header ipv4_t {
+    bit<4>    version;
+    bit<4>    ihl;
+    bit<8>    diffserv;
+    bit<16>   totalLen;
+    bit<16>   identification;
+    bit<3>    flags;
+    bit<13>   fragOffset;
+    bit<8>    ttl;
+    bit<8>    protocol;
+    bit<16>   hdrChecksum;
+    ip4Addr_t srcAddr;
+    ip4Addr_t dstAddr;
+}
+
+struct local_metadata_t {
+    bit<10> vrf;
+    bool vrf_is_valid;
+}
+
+struct headers {
+    ethernet_t   ethernet;
+    ipv4_t       ipv4;
+}
+
+/*************************************************************************
+*********************** P A R S E R  ***********************************
+*************************************************************************/
+
+parser MyParser(packet_in packet,
+                out headers hdr,
+                inout local_metadata_t local_metadata,
+                inout standard_metadata_t standard_metadata) {
+
+    state start {
+        transition parse_ethernet;
+    }
+
+    state parse_ethernet {
+        packet.extract(hdr.ethernet);
+        transition select(hdr.ethernet.etherType) {
+            TYPE_IPV4: parse_ipv4;
+            default: accept;
+        }
+    }
+
+    state parse_ipv4 {
+        packet.extract(hdr.ipv4);
+        transition accept;
+    }
+
+}
+
+/*************************************************************************
+************   C H E C K S U M    V E R I F I C A T I O N   *************
+*************************************************************************/
+
+control MyVerifyChecksum(inout headers hdr, inout local_metadata_t local_metadata) {   
+    apply {  }
+}
+
+
+/*************************************************************************
+**************  I N G R E S S   P R O C E S S I N G   *******************
+*************************************************************************/
+
+control MyIngress(inout headers hdr,
+                  inout local_metadata_t local_metadata,
+                  inout standard_metadata_t standard_metadata) {
+
+    // NoAction: 21257015
+    // 25652968
+    action drop() {
+        mark_to_drop(standard_metadata);
+    }
+
+    // 24959910
+    action set_vrf(bit<10> vrf) {
+      local_metadata.vrf = vrf;
+      local_metadata.vrf_is_valid = true;
+    }
+
+    // 28792405
+    action ipv4_forward(macAddr_t dstAddr, egressSpec_t port) {
+        standard_metadata.egress_spec = port;
+        hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
+        hdr.ethernet.dstAddr = dstAddr;
+        hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
+    }
+
+    // 37105383
+    table set_vrf_table {
+        key = {
+            hdr.ipv4.srcAddr: ternary @format(IPV4_ADDRESS);
+        }
+        actions = {
+            @proto_id(1) set_vrf;
+            @proto_id(2) NoAction;
+        }
+        size = 1024;
+        default_action = NoAction;
+    }
+
+    // 45604648
+    table ipv4_lpm_table {
+        key = {
+            hdr.ipv4.dstAddr: lpm @format(IPV4_ADDRESS);
+            local_metadata.vrf: exact;
+        }
+        actions = {
+            @proto_id(1) ipv4_forward;
+            @proto_id(2) drop;
+        }
+        size = 1024;
+        default_action = drop();
+    }
+    
+    apply {
+        // vrf is not valid by default.
+        local_metadata.vrf_is_valid = false;
+
+        // Check that the packet is an ipv4 packet.
+        if (hdr.ipv4.isValid()) {
+            // Set a vrf.
+            set_vrf_table.apply();
+            if (local_metadata.vrf_is_valid) {
+              // If vrf was set, do lpm matching on dst to route.
+              ipv4_lpm_table.apply();
+            }   
+        }
+    }
+}
+
+/*************************************************************************
+****************  E G R E S S   P R O C E S S I N G   *******************
+*************************************************************************/
+
+control MyEgress(inout headers hdr,
+                 inout local_metadata_t local_metadata,
+                 inout standard_metadata_t standard_metadata) {
+    apply {  }
+}
+
+/*************************************************************************
+*************   C H E C K S U M    C O M P U T A T I O N   **************
+*************************************************************************/
+
+control MyComputeChecksum(inout headers  hdr, inout local_metadata_t local_metadata) {
+    apply {
+	      update_checksum(
+      	    hdr.ipv4.isValid(),
+            { hdr.ipv4.version,
+	            hdr.ipv4.ihl,
+              hdr.ipv4.diffserv,
+              hdr.ipv4.totalLen,
+              hdr.ipv4.identification,
+              hdr.ipv4.flags,
+              hdr.ipv4.fragOffset,
+              hdr.ipv4.ttl,
+              hdr.ipv4.protocol,
+              hdr.ipv4.srcAddr,
+              hdr.ipv4.dstAddr },
+            hdr.ipv4.hdrChecksum,
+            HashAlgorithm.csum16);
+    }
+}
+
+/*************************************************************************
+***********************  D E P A R S E R  *******************************
+*************************************************************************/
+
+control MyDeparser(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+/*************************************************************************
+***********************  S W I T C H  *******************************
+*************************************************************************/
+
+V1Switch(
+MyParser(),
+MyVerifyChecksum(),
+MyIngress(),
+MyEgress(),
+MyComputeChecksum(),
+MyDeparser()
+) main;

--- a/p4-samples/vrf-routing/vrf.p4
+++ b/p4-samples/vrf-routing/vrf.p4
@@ -78,18 +78,19 @@ control packet_ingress(inout headers hdr,
                        inout local_metadata_t local_metadata,
                        inout standard_metadata_t standard_metadata) {
   // NoAction: 21257015
-  // 25652968
+
+  // 26764252
   action drop() {
     mark_to_drop(standard_metadata);
   }
 
-  // 24959910
+  // 26074559
   action set_vrf(bit<10> vrf) {
     local_metadata.vrf = vrf;
     local_metadata.vrf_is_valid = true;
   }
 
-  // 28792405
+  // 27807574
   action ipv4_forward(mac_addr_t dstAddr, egress_spec_t port) {
     standard_metadata.egress_spec = port;
     hdr.ethernet.srcAddr = hdr.ethernet.dstAddr;
@@ -97,7 +98,7 @@ control packet_ingress(inout headers hdr,
     hdr.ipv4.ttl = hdr.ipv4.ttl - 1;
   }
 
-  // 37105383
+  // 37541331
   table set_vrf_table {
     key = {
       hdr.ipv4.srcAddr: ternary @format(IPV4_ADDRESS);
@@ -110,7 +111,7 @@ control packet_ingress(inout headers hdr,
     default_action = NoAction;
   }
 
-  // 45604648
+  // 44809600
   table ipv4_lpm_table {
     key = {
       hdr.ipv4.dstAddr: lpm @format(IPV4_ADDRESS);


### PR DESCRIPTION
This PR adds a new p4 sample program with a bit more elaborate flow

The program consists of two tables: the first sets the vrf via ternary matching on ipv4.srcAddr, and the second matches on it along side an lpm on ip4.dstAddr.

Both tables applications are guarded, the first is guarded by the validity of the ipv4 headers, the second by both validity of ipv4 headers and the vrf, checked via a boolean flag.

I did not add the program to the CI yet. We can have a bit of a discussion about it:
1. The SMT formula for the program is deterministic so it is easy to add as a golden file test.
2. The output packets are not, the ternary and lpm matches leave a lot of freedom in how they can be satisfied, the solver will return slightly different combinations every-time it is run non-deterministically.

This relates to a previous discussion we had. I think it is better to do some semantic checking on the output packets rather than just syntactic checks. We have two options:
1. The testing logic reads the output packet per table entry, and checks that it satisfies a pattern (each entry will have its own pattern). For example, it checks that the vrf is set to the appropriate value that the entry sets it to. This is the least amount of work but the most inflexible approach.
2. The testing logic feeds the input packet to bmv2, checks the output packet is identical to the expected one that the solver returns, additionally, if the testing logic can hook up to bmv2 and monitor which entries and branches were taken, these can be validated against the solver's predictions as well.

It is unlikely I will get to do either of these options before the end of the week. I am leaving them here for discussion and documentation purposes, and will also explicitly state them in the design docs I am doing next.