### PR TITLE
Support string translation around the solver boundry

### DIFF
--- a/p4-samples/vrf-routing/entries.pb.txt
+++ b/p4-samples/vrf-routing/entries.pb.txt
@@ -15,7 +15,7 @@ updates {
           action_id: 26074559
           params {
             param_id: 1
-            value: "\02"
+            value: "VRF2"
           }
         }
       }
@@ -40,7 +40,7 @@ updates {
           action_id: 26074559
           params {
             param_id: 1
-            value: "\01"
+            value: "VRF1"
           }
         }
       }
@@ -63,7 +63,7 @@ updates {
       match {
         field_id: 2,
         exact {
-          value: "\01"
+          value: "VRF1"
         }
       }
       action {
@@ -97,7 +97,7 @@ updates {
       match {
         field_id: 2,
         exact {
-          value: "\01"
+          value: "VRF1"
         }
       }
       action {
@@ -131,7 +131,7 @@ updates {
       match {
         field_id: 2,
         exact {
-          value: "\01"
+          value: "VRF1"
         }
       }
       action {
@@ -165,7 +165,7 @@ updates {
       match {
         field_id: 2,
         exact {
-          value: "\02"
+          value: "VRF2"
         }
       }
       action {

--- a/p4-samples/vrf-routing/vrf.p4
+++ b/p4-samples/vrf-routing/vrf.p4
@@ -23,7 +23,7 @@ typedef bit<48> mac_addr_t;
 typedef bit<32> ipv4_addr_t;
 
 @p4runtime_translation("", string) 
-typedef bit<10> vrf_t;
+type bit<10> vrf_t;
 
 header ethernet_t {
   mac_addr_t dstAddr;

--- a/p4-samples/vrf-routing/vrf.p4
+++ b/p4-samples/vrf-routing/vrf.p4
@@ -22,6 +22,9 @@ typedef bit<9> egress_spec_t;
 typedef bit<48> mac_addr_t;
 typedef bit<32> ipv4_addr_t;
 
+@p4runtime_translation("", string) 
+typedef bit<10> vrf_t;
+
 header ethernet_t {
   mac_addr_t dstAddr;
   mac_addr_t srcAddr;
@@ -46,7 +49,7 @@ struct headers {
   ipv4_t ipv4;
 }
 struct local_metadata_t {
-  bit<10> vrf;
+  vrf_t vrf;
   bool vrf_is_valid;
 }
 
@@ -85,7 +88,7 @@ control packet_ingress(inout headers hdr,
   }
 
   // 26074559
-  action set_vrf(bit<10> vrf) {
+  action set_vrf(vrf_t vrf) {
     local_metadata.vrf = vrf;
     local_metadata.vrf_is_valid = true;
   }

--- a/p4_symbolic/symbolic/BUILD.bazel
+++ b/p4_symbolic/symbolic/BUILD.bazel
@@ -28,6 +28,7 @@ cc_library(
         "symbolic.cc",
         "table.cc",
         "util.cc",
+        "values.cc",
     ],
     hdrs = [
         "action.h",
@@ -40,6 +41,7 @@ cc_library(
         "symbolic.h",
         "table.h",
         "util.h",
+        "values.h",
     ],
     visibility = ["//p4_symbolic:__subpackages__"],
     deps = [

--- a/p4_symbolic/symbolic/action.cc
+++ b/p4_symbolic/symbolic/action.cc
@@ -305,7 +305,7 @@ absl::Status EvaluateAction(const ir::Action &action,
                             const google::protobuf::RepeatedPtrField<
                                 pdpi::IrActionInvocation::IrActionParam> &args,
                             SymbolicPerPacketState *state,
-                            EvaluationEnvironment *environment,
+                            values::P4RuntimeTranslator *translator,
                             const z3::expr &guard) {
   // Construct this action's context.
   ActionContext context;
@@ -325,9 +325,12 @@ absl::Status EvaluateAction(const ir::Action &action,
     const pdpi::IrActionDefinition::IrActionParamDefinition &parameter =
         parameters.at(i);
     const std::string &parameter_name = parameter.param().name();
-    ASSIGN_OR_RETURN(z3::expr parameter_value,
-                     environment->value_formatter.FormatP4RTValue(
-                         parameter_name, args.at(i - 1).value()));
+    const std::string &parameter_type_name =
+        parameter.param().type_name().name();
+    ASSIGN_OR_RETURN(
+        z3::expr parameter_value,
+        values::FormatP4RTValue("", parameter_type_name, args.at(i - 1).value(),
+                                translator));
     context.scope.insert({parameter_name, parameter_value});
   }
 

--- a/p4_symbolic/symbolic/action.cc
+++ b/p4_symbolic/symbolic/action.cc
@@ -18,7 +18,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "p4_symbolic/symbolic/operators.h"
-#include "p4_symbolic/symbolic/util.h"
+#include "p4_symbolic/symbolic/values.h"
 
 namespace p4_symbolic {
 namespace symbolic {
@@ -162,8 +162,8 @@ gutil::StatusOr<z3::expr> EvaluateHexStr(const ir::HexstrValue &hexstr) {
   }
 
   ASSIGN_OR_RETURN(pdpi::IrValue parsed_value,
-                   util::StringToIrValue(hexstr.value()));
-  return util::IrValueToZ3Expr(parsed_value);
+                   values::ParseIrValue(hexstr.value()));
+  return values::Bmv2ValueZ3Expr(parsed_value);
 }
 
 gutil::StatusOr<z3::expr> EvaluateBool(const ir::BoolValue &bool_value) {
@@ -325,8 +325,9 @@ absl::Status EvaluateAction(const ir::Action &action,
     const pdpi::IrActionDefinition::IrActionParamDefinition &parameter =
         parameters.at(i);
     const std::string &parameter_name = parameter.param().name();
-    ASSIGN_OR_RETURN(z3::expr parameter_value,
-                     util::IrValueToZ3Expr(args.at(i - 1).value()));
+    ASSIGN_OR_RETURN(
+        z3::expr parameter_value,
+        values::P4RTValueZ3Expr(parameter_name, args.at(i - 1).value()));
     context.scope.insert({parameter_name, parameter_value});
   }
 

--- a/p4_symbolic/symbolic/action.cc
+++ b/p4_symbolic/symbolic/action.cc
@@ -18,7 +18,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "p4_symbolic/symbolic/operators.h"
-#include "p4_symbolic/symbolic/values.h"
 
 namespace p4_symbolic {
 namespace symbolic {
@@ -163,7 +162,7 @@ gutil::StatusOr<z3::expr> EvaluateHexStr(const ir::HexstrValue &hexstr) {
 
   ASSIGN_OR_RETURN(pdpi::IrValue parsed_value,
                    values::ParseIrValue(hexstr.value()));
-  return values::Bmv2ValueZ3Expr(parsed_value);
+  return values::FormatBmv2Value(parsed_value);
 }
 
 gutil::StatusOr<z3::expr> EvaluateBool(const ir::BoolValue &bool_value) {
@@ -306,6 +305,7 @@ absl::Status EvaluateAction(const ir::Action &action,
                             const google::protobuf::RepeatedPtrField<
                                 pdpi::IrActionInvocation::IrActionParam> &args,
                             SymbolicPerPacketState *state,
+                            EvaluationEnvironment *environment,
                             const z3::expr &guard) {
   // Construct this action's context.
   ActionContext context;
@@ -325,9 +325,9 @@ absl::Status EvaluateAction(const ir::Action &action,
     const pdpi::IrActionDefinition::IrActionParamDefinition &parameter =
         parameters.at(i);
     const std::string &parameter_name = parameter.param().name();
-    ASSIGN_OR_RETURN(
-        z3::expr parameter_value,
-        values::P4RTValueZ3Expr(parameter_name, args.at(i - 1).value()));
+    ASSIGN_OR_RETURN(z3::expr parameter_value,
+                     environment->value_formatter.FormatP4RTValue(
+                         parameter_name, args.at(i - 1).value()));
     context.scope.insert({parameter_name, parameter_value});
   }
 

--- a/p4_symbolic/symbolic/action.h
+++ b/p4_symbolic/symbolic/action.h
@@ -28,6 +28,7 @@
 #include "p4_pdpi/ir.pb.h"
 #include "p4_symbolic/ir/ir.pb.h"
 #include "p4_symbolic/symbolic/symbolic.h"
+#include "p4_symbolic/symbolic/values.h"
 #include "z3++.h"
 
 namespace p4_symbolic {
@@ -42,6 +43,7 @@ absl::Status EvaluateAction(const ir::Action &action,
                             const google::protobuf::RepeatedPtrField<
                                 pdpi::IrActionInvocation::IrActionParam> &args,
                             SymbolicPerPacketState *state,
+                            EvaluationEnvironment *environment,
                             const z3::expr &guard);
 
 // Internal functions used to Evaluate statements and expressions within an

--- a/p4_symbolic/symbolic/action.h
+++ b/p4_symbolic/symbolic/action.h
@@ -43,7 +43,7 @@ absl::Status EvaluateAction(const ir::Action &action,
                             const google::protobuf::RepeatedPtrField<
                                 pdpi::IrActionInvocation::IrActionParam> &args,
                             SymbolicPerPacketState *state,
-                            EvaluationEnvironment *environment,
+                            values::P4RuntimeTranslator *translator,
                             const z3::expr &guard);
 
 // Internal functions used to Evaluate statements and expressions within an

--- a/p4_symbolic/symbolic/conditional.cc
+++ b/p4_symbolic/symbolic/conditional.cc
@@ -28,7 +28,7 @@ namespace conditional {
 
 gutil::StatusOr<SymbolicTrace> EvaluateConditional(
     const Dataplane data_plane, const ir::Conditional &conditional,
-    SymbolicPerPacketState *state, EvaluationEnvironment *environment,
+    SymbolicPerPacketState *state, values::P4RuntimeTranslator *translator,
     const z3::expr &guard) {
   // Evaluate the condition.
   action::ActionContext fake_context = {conditional.name(), {}};
@@ -45,11 +45,11 @@ gutil::StatusOr<SymbolicTrace> EvaluateConditional(
   // Evaluate both branches.
   ASSIGN_OR_RETURN(SymbolicTrace if_trace,
                    control::EvaluateControl(data_plane, conditional.if_branch(),
-                                            state, environment, if_guard));
+                                            state, translator, if_guard));
   ASSIGN_OR_RETURN(
       SymbolicTrace else_trace,
       control::EvaluateControl(data_plane, conditional.else_branch(), state,
-                               environment, else_guard));
+                               translator, else_guard));
 
   // Now we have two traces that need merging.
   // We should merge in a way such that the value of a field in the trace is

--- a/p4_symbolic/symbolic/conditional.cc
+++ b/p4_symbolic/symbolic/conditional.cc
@@ -28,7 +28,8 @@ namespace conditional {
 
 gutil::StatusOr<SymbolicTrace> EvaluateConditional(
     const Dataplane data_plane, const ir::Conditional &conditional,
-    SymbolicPerPacketState *state, const z3::expr &guard) {
+    SymbolicPerPacketState *state, EvaluationEnvironment *environment,
+    const z3::expr &guard) {
   // Evaluate the condition.
   action::ActionContext fake_context = {conditional.name(), {}};
   ASSIGN_OR_RETURN(
@@ -44,11 +45,11 @@ gutil::StatusOr<SymbolicTrace> EvaluateConditional(
   // Evaluate both branches.
   ASSIGN_OR_RETURN(SymbolicTrace if_trace,
                    control::EvaluateControl(data_plane, conditional.if_branch(),
-                                            state, if_guard));
+                                            state, environment, if_guard));
   ASSIGN_OR_RETURN(
       SymbolicTrace else_trace,
       control::EvaluateControl(data_plane, conditional.else_branch(), state,
-                               else_guard));
+                               environment, else_guard));
 
   // Now we have two traces that need merging.
   // We should merge in a way such that the value of a field in the trace is

--- a/p4_symbolic/symbolic/conditional.h
+++ b/p4_symbolic/symbolic/conditional.h
@@ -22,6 +22,7 @@
 #include "p4_symbolic/ir/ir.pb.h"
 #include "p4_symbolic/symbolic/control.h"
 #include "p4_symbolic/symbolic/symbolic.h"
+#include "p4_symbolic/symbolic/values.h"
 #include "z3++.h"
 
 namespace p4_symbolic {
@@ -30,7 +31,8 @@ namespace conditional {
 
 gutil::StatusOr<SymbolicTrace> EvaluateConditional(
     const Dataplane data_plane, const ir::Conditional &table,
-    SymbolicPerPacketState *state, const z3::expr &guard);
+    SymbolicPerPacketState *state, EvaluationEnvironment *environment,
+    const z3::expr &guard);
 
 }  // namespace conditional
 }  // namespace symbolic

--- a/p4_symbolic/symbolic/conditional.h
+++ b/p4_symbolic/symbolic/conditional.h
@@ -31,7 +31,7 @@ namespace conditional {
 
 gutil::StatusOr<SymbolicTrace> EvaluateConditional(
     const Dataplane data_plane, const ir::Conditional &table,
-    SymbolicPerPacketState *state, EvaluationEnvironment *environment,
+    SymbolicPerPacketState *state, values::P4RuntimeTranslator *translator,
     const z3::expr &guard);
 
 }  // namespace conditional

--- a/p4_symbolic/symbolic/control.cc
+++ b/p4_symbolic/symbolic/control.cc
@@ -34,7 +34,7 @@ namespace control {
 
 gutil::StatusOr<SymbolicTrace> EvaluateControl(
     const Dataplane &data_plane, const std::string &control_name,
-    SymbolicPerPacketState *state, EvaluationEnvironment *environment,
+    SymbolicPerPacketState *state, values::P4RuntimeTranslator *translator,
     const z3::expr &guard) {
   // Base case: we got to the end of the evaluation, no more controls!
   if (control_name.empty()) {
@@ -50,13 +50,13 @@ gutil::StatusOr<SymbolicTrace> EvaluateControl(
       table_entries = data_plane.entries.at(control_name);
     }
     return table::EvaluateTable(data_plane, table, table_entries, state,
-                                environment, guard);
+                                translator, guard);
   } else if (data_plane.program.conditionals().count(control_name) == 1) {
     // Conditional: let EvaluateConditional handle it.
     const ir::Conditional &conditional =
         data_plane.program.conditionals().at(control_name);
     return conditional::EvaluateConditional(data_plane, conditional, state,
-                                            environment, guard);
+                                            translator, guard);
   } else {
     // Something else: unsupported.
     return absl::UnimplementedError(

--- a/p4_symbolic/symbolic/control.h
+++ b/p4_symbolic/symbolic/control.h
@@ -61,6 +61,7 @@
 
 #include "gutil/status.h"
 #include "p4_symbolic/symbolic/symbolic.h"
+#include "p4_symbolic/symbolic/values.h"
 #include "z3++.h"
 
 namespace p4_symbolic {
@@ -68,10 +69,10 @@ namespace symbolic {
 namespace control {
 
 // Evaluate the passed control construct.
-gutil::StatusOr<SymbolicTrace> EvaluateControl(const Dataplane &data_plane,
-                                               const std::string &control_name,
-                                               SymbolicPerPacketState *state,
-                                               const z3::expr &guard);
+gutil::StatusOr<SymbolicTrace> EvaluateControl(
+    const Dataplane &data_plane, const std::string &control_name,
+    SymbolicPerPacketState *state, EvaluationEnvironment *environment,
+    const z3::expr &guard);
 
 }  // namespace control
 }  // namespace symbolic

--- a/p4_symbolic/symbolic/control.h
+++ b/p4_symbolic/symbolic/control.h
@@ -71,7 +71,7 @@ namespace control {
 // Evaluate the passed control construct.
 gutil::StatusOr<SymbolicTrace> EvaluateControl(
     const Dataplane &data_plane, const std::string &control_name,
-    SymbolicPerPacketState *state, EvaluationEnvironment *environment,
+    SymbolicPerPacketState *state, values::P4RuntimeTranslator *translator,
     const z3::expr &guard);
 
 }  // namespace control

--- a/p4_symbolic/symbolic/packet.cc
+++ b/p4_symbolic/symbolic/packet.cc
@@ -38,6 +38,7 @@ z3::expr GetOrDefault(SymbolicPerPacketState state, const std::string &field,
 }  // namespace
 
 SymbolicPacket ExtractSymbolicPacket(SymbolicPerPacketState state) {
+  z3::expr ipv6_src = GetOrDefault(state, "ipv6.src_addr", 128);
   z3::expr ipv6_dst = GetOrDefault(state, "ipv6.dst_addr", 128);
 
   return {GetOrDefault(state, "ethernet.src_addr", 48),
@@ -55,59 +56,20 @@ SymbolicPacket ExtractSymbolicPacket(SymbolicPerPacketState state) {
           GetOrDefault(state, "icmp.type", 8)};
 }
 
-gutil::StatusOr<ConcretePacket> ExtractConcretePacket(
-    SymbolicPacket packet, z3::model model,
-    const values::ValueFormatter &value_formatter) {
-  ASSIGN_OR_RETURN(
-      std::string src_addr,
-      value_formatter.TranslateValueToString(
-          "ethernet.src_addr", model.eval(packet.eth_src, true).to_string()));
-  ASSIGN_OR_RETURN(
-      std::string dst_addr,
-      value_formatter.TranslateValueToString(
-          "ethernet.dst_addr", model.eval(packet.eth_dst, true).to_string()));
-  ASSIGN_OR_RETURN(std::string ether_type,
-                   value_formatter.TranslateValueToString(
-                       "ethernet.ether_type",
-                       model.eval(packet.eth_type, true).to_string()));
+ConcretePacket ExtractConcretePacket(SymbolicPacket packet, z3::model model) {
+  return {model.eval(packet.eth_src, true).to_string(),
+          model.eval(packet.eth_dst, true).to_string(),
+          model.eval(packet.eth_type, true).to_string(),
 
-  ASSIGN_OR_RETURN(
-      std::string ipv4_src_addr,
-      value_formatter.TranslateValueToString(
-          "ipv4.src_addr", model.eval(packet.ipv4_src, true).to_string()));
-  ASSIGN_OR_RETURN(
-      std::string ipv4_dst_addr,
-      value_formatter.TranslateValueToString(
-          "ipv4.dst_addr", model.eval(packet.ipv4_dst, true).to_string()));
+          model.eval(packet.ipv4_src, true).to_string(),
+          model.eval(packet.ipv4_dst, true).to_string(),
+          model.eval(packet.ipv6_dst_upper, true).to_string(),
+          model.eval(packet.ipv6_dst_lower, true).to_string(),
+          model.eval(packet.protocol, true).to_string(),
+          model.eval(packet.dscp, true).to_string(),
+          model.eval(packet.ttl, true).to_string(),
 
-  // Lower and upper ipv6_dst cant have string translations since they
-  // are not whole values!
-  std::string ipv6_dst_upper =
-      model.eval(packet.ipv6_dst_upper, true).to_string();
-  std::string ipv6_dst_lower =
-      model.eval(packet.ipv6_dst_lower, true).to_string();
-
-  // Remaining fields may have string translation.
-  ASSIGN_OR_RETURN(
-      std::string protocol,
-      value_formatter.TranslateValueToString(
-          "ipv4.protocol", model.eval(packet.protocol, true).to_string()));
-  ASSIGN_OR_RETURN(std::string dscp,
-                   value_formatter.TranslateValueToString(
-                       "ipv4.dscp", model.eval(packet.dscp, true).to_string()));
-  ASSIGN_OR_RETURN(std::string ttl,
-                   value_formatter.TranslateValueToString(
-                       "ipv4.ttl", model.eval(packet.ttl, true).to_string()));
-
-  ASSIGN_OR_RETURN(
-      std::string icmp_type,
-      value_formatter.TranslateValueToString(
-          "icmp.type", model.eval(packet.icmp_type, true).to_string()));
-
-  return ConcretePacket{
-      src_addr,       dst_addr,       ether_type, ipv4_src_addr, ipv4_dst_addr,
-      ipv6_dst_upper, ipv6_dst_lower, protocol,   dscp,          ttl,
-      icmp_type};
+          model.eval(packet.icmp_type, true).to_string()};
 }
 
 }  // namespace packet

--- a/p4_symbolic/symbolic/packet.cc
+++ b/p4_symbolic/symbolic/packet.cc
@@ -19,8 +19,6 @@
 
 #include <string>
 
-#include "p4_symbolic/symbolic/values.h"
-
 namespace p4_symbolic {
 namespace symbolic {
 namespace packet {
@@ -57,28 +55,29 @@ SymbolicPacket ExtractSymbolicPacket(SymbolicPerPacketState state) {
           GetOrDefault(state, "icmp.type", 8)};
 }
 
-gutil::StatusOr<ConcretePacket> ExtractConcretePacket(SymbolicPacket packet,
-                                                      z3::model model) {
+gutil::StatusOr<ConcretePacket> ExtractConcretePacket(
+    SymbolicPacket packet, z3::model model,
+    const values::ValueFormatter &value_formatter) {
   ASSIGN_OR_RETURN(
       std::string src_addr,
-      values::TranslateValueToString(
+      value_formatter.TranslateValueToString(
           "ethernet.src_addr", model.eval(packet.eth_src, true).to_string()));
   ASSIGN_OR_RETURN(
       std::string dst_addr,
-      values::TranslateValueToString(
+      value_formatter.TranslateValueToString(
           "ethernet.dst_addr", model.eval(packet.eth_dst, true).to_string()));
   ASSIGN_OR_RETURN(std::string ether_type,
-                   values::TranslateValueToString(
+                   value_formatter.TranslateValueToString(
                        "ethernet.ether_type",
                        model.eval(packet.eth_type, true).to_string()));
 
   ASSIGN_OR_RETURN(
       std::string ipv4_src_addr,
-      values::TranslateValueToString(
+      value_formatter.TranslateValueToString(
           "ipv4.src_addr", model.eval(packet.ipv4_src, true).to_string()));
   ASSIGN_OR_RETURN(
       std::string ipv4_dst_addr,
-      values::TranslateValueToString(
+      value_formatter.TranslateValueToString(
           "ipv4.dst_addr", model.eval(packet.ipv4_dst, true).to_string()));
 
   // Lower and upper ipv6_dst cant have string translations since they
@@ -91,18 +90,18 @@ gutil::StatusOr<ConcretePacket> ExtractConcretePacket(SymbolicPacket packet,
   // Remaining fields may have string translation.
   ASSIGN_OR_RETURN(
       std::string protocol,
-      values::TranslateValueToString(
+      value_formatter.TranslateValueToString(
           "ipv4.protocol", model.eval(packet.protocol, true).to_string()));
   ASSIGN_OR_RETURN(std::string dscp,
-                   values::TranslateValueToString(
+                   value_formatter.TranslateValueToString(
                        "ipv4.dscp", model.eval(packet.dscp, true).to_string()));
   ASSIGN_OR_RETURN(std::string ttl,
-                   values::TranslateValueToString(
+                   value_formatter.TranslateValueToString(
                        "ipv4.ttl", model.eval(packet.ttl, true).to_string()));
 
   ASSIGN_OR_RETURN(
       std::string icmp_type,
-      values::TranslateValueToString(
+      value_formatter.TranslateValueToString(
           "icmp.type", model.eval(packet.icmp_type, true).to_string()));
 
   return ConcretePacket{

--- a/p4_symbolic/symbolic/packet.h
+++ b/p4_symbolic/symbolic/packet.h
@@ -20,7 +20,6 @@
 
 #include "gutil/status.h"
 #include "p4_symbolic/symbolic/symbolic.h"
-#include "p4_symbolic/symbolic/values.h"
 #include "z3++.h"
 
 namespace p4_symbolic {
@@ -32,9 +31,7 @@ SymbolicPacket ExtractSymbolicPacket(SymbolicPerPacketState state);
 
 // Extract a concrete packet by evaluating every field's corresponding
 // expression in the model.
-gutil::StatusOr<ConcretePacket> ExtractConcretePacket(
-    SymbolicPacket packet, z3::model model,
-    const values::ValueFormatter &value_formatter);
+ConcretePacket ExtractConcretePacket(SymbolicPacket packet, z3::model model);
 
 }  // namespace packet
 }  // namespace symbolic

--- a/p4_symbolic/symbolic/packet.h
+++ b/p4_symbolic/symbolic/packet.h
@@ -20,6 +20,7 @@
 
 #include "gutil/status.h"
 #include "p4_symbolic/symbolic/symbolic.h"
+#include "p4_symbolic/symbolic/values.h"
 #include "z3++.h"
 
 namespace p4_symbolic {
@@ -31,8 +32,9 @@ SymbolicPacket ExtractSymbolicPacket(SymbolicPerPacketState state);
 
 // Extract a concrete packet by evaluating every field's corresponding
 // expression in the model.
-gutil::StatusOr<ConcretePacket> ExtractConcretePacket(SymbolicPacket packet,
-                                                      z3::model model);
+gutil::StatusOr<ConcretePacket> ExtractConcretePacket(
+    SymbolicPacket packet, z3::model model,
+    const values::ValueFormatter &value_formatter);
 
 }  // namespace packet
 }  // namespace symbolic

--- a/p4_symbolic/symbolic/packet.h
+++ b/p4_symbolic/symbolic/packet.h
@@ -18,6 +18,7 @@
 #ifndef P4_SYMBOLIC_SYMBOLIC_PACKET_H_
 #define P4_SYMBOLIC_SYMBOLIC_PACKET_H_
 
+#include "gutil/status.h"
 #include "p4_symbolic/symbolic/symbolic.h"
 #include "z3++.h"
 
@@ -30,7 +31,8 @@ SymbolicPacket ExtractSymbolicPacket(SymbolicPerPacketState state);
 
 // Extract a concrete packet by evaluating every field's corresponding
 // expression in the model.
-ConcretePacket ExtractConcretePacket(SymbolicPacket packet, z3::model model);
+gutil::StatusOr<ConcretePacket> ExtractConcretePacket(SymbolicPacket packet,
+                                                      z3::model model);
 
 }  // namespace packet
 }  // namespace symbolic

--- a/p4_symbolic/symbolic/symbolic.cc
+++ b/p4_symbolic/symbolic/symbolic.cc
@@ -51,6 +51,11 @@ gutil::StatusOr<std::unique_ptr<SolverState>> EvaluateP4Pipeline(
     }
   }
 
+  // Initially, the evaluation environment contains an empty value formatter.
+  // The formatter will be filled translation maps between string values and
+  // their corresponding bitvectors.
+  EvaluationEnvironment environment = {values::ValueFormatter()};
+
   // "Accumulator"-style p4 program headers.
   // This is used to evaluate the P4 program.
   // Initially free/unconstrained and contains symbolic variables for
@@ -67,7 +72,8 @@ gutil::StatusOr<std::unique_ptr<SolverState>> EvaluateP4Pipeline(
   ASSIGN_OR_RETURN(
       SymbolicTrace trace,
       control::EvaluateControl(data_plane, data_plane.program.initial_control(),
-                               &egress_headers, Z3Context().bool_val(true)));
+                               &egress_headers, &environment,
+                               Z3Context().bool_val(true)));
 
   // Alias the event that the packet is dropped for ease of use in assertions.
   z3::expr dropped_value =
@@ -110,7 +116,8 @@ gutil::StatusOr<std::unique_ptr<SolverState>> EvaluateP4Pipeline(
       ingress_headers, egress_headers, trace};
 
   return std::make_unique<SolverState>(data_plane.program, data_plane.entries,
-                                       symbolic_context, std::move(z3_solver));
+                                       symbolic_context, std::move(z3_solver),
+                                       environment);
 }
 
 gutil::StatusOr<std::optional<ConcreteContext>> Solve(
@@ -134,7 +141,9 @@ gutil::StatusOr<std::optional<ConcreteContext>> Solve(
       z3::model packet_model = solver_state->solver->get_model();
       ASSIGN_OR_RETURN(
           ConcreteContext result,
-          util::ExtractFromModel(solver_state->context, packet_model));
+          util::ExtractFromModel(
+              solver_state->context, packet_model,
+              solver_state->evaluation_environemnt.value_formatter));
       solver_state->solver->pop();
       return std::make_optional<ConcreteContext>(result);
   }

--- a/p4_symbolic/symbolic/symbolic.cc
+++ b/p4_symbolic/symbolic/symbolic.cc
@@ -132,8 +132,9 @@ gutil::StatusOr<std::optional<ConcreteContext>> Solve(
     case z3::sat:
     default:
       z3::model packet_model = solver_state->solver->get_model();
-      ConcreteContext result =
-          util::ExtractFromModel(solver_state->context, packet_model);
+      ASSIGN_OR_RETURN(
+          ConcreteContext result,
+          util::ExtractFromModel(solver_state->context, packet_model));
       solver_state->solver->pop();
       return std::make_optional<ConcreteContext>(result);
   }

--- a/p4_symbolic/symbolic/symbolic.h
+++ b/p4_symbolic/symbolic/symbolic.h
@@ -45,12 +45,6 @@ namespace symbolic {
 // evaluation.
 z3::context &Z3Context();
 
-// This struct contains any metadata or information that needs to be passed
-// around, maintained, or modified by the various evaluation functions.
-struct EvaluationEnvironment {
-  values::ValueFormatter value_formatter;
-};
-
 // Maps the name of a header field in the p4 program to its concrete value.
 using ConcretePerPacketState = std::unordered_map<std::string, std::string>;
 
@@ -249,18 +243,18 @@ struct SolverState {
   // deductions it made while solving for one particular assertion, and re-use
   // them during solving with future assertions.
   std::unique_ptr<z3::solver> solver;
-  // Store the evaluation environment for use by .Solve(...).
-  EvaluationEnvironment evaluation_environemnt;
+  // Store the p4 runtime translator state for use by .Solve(...).
+  values::P4RuntimeTranslator translator;
   // Need this constructor to be defined explicity to be able to use make_unique
   // on this struct.
   SolverState(ir::P4Program program, ir::TableEntries entries,
               SymbolicContext context, std::unique_ptr<z3::solver> &&solver,
-              EvaluationEnvironment evaluation_environemnt)
+              values::P4RuntimeTranslator translator)
       : program(program),
         entries(entries),
         context(context),
         solver(std::move(solver)),
-        evaluation_environemnt(evaluation_environemnt) {}
+        translator(translator) {}
 };
 
 // An assertion is a user defined function that takes a symbolic context

--- a/p4_symbolic/symbolic/table.h
+++ b/p4_symbolic/symbolic/table.h
@@ -39,7 +39,7 @@ namespace table {
 gutil::StatusOr<SymbolicTrace> EvaluateTable(
     const Dataplane data_plane, const ir::Table &table,
     const std::vector<pdpi::IrTableEntry> &entries,
-    SymbolicPerPacketState *state, EvaluationEnvironment *environment,
+    SymbolicPerPacketState *state, values::P4RuntimeTranslator *translator,
     const z3::expr &guard);
 
 }  // namespace table

--- a/p4_symbolic/symbolic/table.h
+++ b/p4_symbolic/symbolic/table.h
@@ -30,6 +30,7 @@
 #include "p4_symbolic/ir/ir.pb.h"
 #include "p4_symbolic/symbolic/control.h"
 #include "p4_symbolic/symbolic/symbolic.h"
+#include "p4_symbolic/symbolic/values.h"
 
 namespace p4_symbolic {
 namespace symbolic {
@@ -38,7 +39,8 @@ namespace table {
 gutil::StatusOr<SymbolicTrace> EvaluateTable(
     const Dataplane data_plane, const ir::Table &table,
     const std::vector<pdpi::IrTableEntry> &entries,
-    SymbolicPerPacketState *state, const z3::expr &guard);
+    SymbolicPerPacketState *state, EvaluationEnvironment *environment,
+    const z3::expr &guard);
 
 }  // namespace table
 }  // namespace symbolic

--- a/p4_symbolic/symbolic/util.cc
+++ b/p4_symbolic/symbolic/util.cc
@@ -16,19 +16,13 @@
 
 #include "p4_symbolic/symbolic/util.h"
 
-#include <cstdint>
-#include <locale>
-#include <sstream>
 #include <string>
-#include <vector>
 
-#include "absl/strings/match.h"
 #include "absl/strings/str_format.h"
-#include "absl/strings/str_split.h"
-#include "absl/strings/strip.h"
 #include "p4_pdpi/utils/ir.h"
 #include "p4_symbolic/symbolic/operators.h"
 #include "p4_symbolic/symbolic/packet.h"
+#include "p4_symbolic/symbolic/values.h"
 
 namespace p4_symbolic {
 namespace symbolic {
@@ -88,25 +82,31 @@ SymbolicTableMatch DefaultTableMatch() {
   };
 }
 
-ConcreteContext ExtractFromModel(SymbolicContext context, z3::model model) {
+gutil::StatusOr<ConcreteContext> ExtractFromModel(SymbolicContext context,
+                                                  z3::model model) {
   // Extract ports.
   std::string ingress_port = model.eval(context.ingress_port, true).to_string();
   std::string egress_port = model.eval(context.egress_port, true).to_string();
 
   // Extract an input packet and its predicted output.
-  ConcretePacket ingress_packet =
-      packet::ExtractConcretePacket(context.ingress_packet, model);
-  ConcretePacket egress_packet =
-      packet::ExtractConcretePacket(context.egress_packet, model);
+  ASSIGN_OR_RETURN(
+      ConcretePacket ingress_packet,
+      packet::ExtractConcretePacket(context.ingress_packet, model));
+  ASSIGN_OR_RETURN(ConcretePacket egress_packet,
+                   packet::ExtractConcretePacket(context.egress_packet, model));
 
   // Extract the ingress and egress headers.
   ConcretePerPacketState ingress_headers;
   for (const auto &[name, expr] : context.ingress_headers) {
-    ingress_headers[name] = model.eval(expr, true).to_string();
+    ASSIGN_OR_RETURN(ingress_headers[name],
+                     values::TranslateValueToString(
+                         name, model.eval(expr, true).to_string()));
   }
   ConcretePerPacketState egress_headers;
   for (const auto &[name, expr] : context.egress_headers) {
-    egress_headers[name] = model.eval(expr, true).to_string();
+    ASSIGN_OR_RETURN(egress_headers[name],
+                     values::TranslateValueToString(
+                         name, model.eval(expr, true).to_string()));
   }
 
   // Extract the trace (matches on every table).
@@ -120,8 +120,9 @@ ConcreteContext ExtractFromModel(SymbolicContext context, z3::model model) {
   }
   ConcreteTrace trace = {matches, dropped};
 
-  return {ingress_port,    egress_port,    ingress_packet, egress_packet,
-          ingress_headers, egress_headers, trace};
+  return ConcreteContext{ingress_port,  egress_port,     ingress_packet,
+                         egress_packet, ingress_headers, egress_headers,
+                         trace};
 }
 
 gutil::StatusOr<SymbolicTrace> MergeTracesOnCondition(
@@ -170,113 +171,6 @@ gutil::StatusOr<SymbolicTrace> MergeTracesOnCondition(
   }
 
   return merged;
-}
-
-gutil::StatusOr<z3::expr> IrValueToZ3Expr(const pdpi::IrValue &value) {
-  switch (value.format_case()) {
-    case pdpi::IrValue::kHexStr: {
-      const std::string &hexstr = value.hex_str();
-
-      uint64_t decimal;
-      std::stringstream converter;
-      converter << std::hex << hexstr;
-      if (converter >> decimal) {
-        unsigned int bitsize = 0;
-        uint64_t pow = 1;
-        while (bitsize <= 64 && pow < decimal) {
-          pow = pow * 2;
-          bitsize++;
-        }
-        bitsize = (bitsize > 1 ? bitsize : 1);  // At least 1 bit.
-        return Z3Context().bv_val(std::to_string(decimal).c_str(), bitsize);
-      }
-
-      return absl::InvalidArgumentError(absl::StrCat(
-          "Cannot process hex string \"", hexstr, "\", the value is too big!"));
-    }
-
-    case pdpi::IrValue::kIpv4: {
-      uint32_t ip = 0;
-      std::vector<std::string> ipv4 = absl::StrSplit(value.ipv4(), ".");
-      for (size_t i = 0; i < ipv4.size(); i++) {
-        uint32_t shifted_component = static_cast<uint32_t>(std::stoull(ipv4[i]))
-                                     << ((ipv4.size() - i - 1) * 8);
-        ip += shifted_component;
-      }
-      return Z3Context().bv_val(std::to_string(ip).c_str(), 32);
-    }
-
-    case pdpi::IrValue::kMac: {
-      uint64_t mac = 0;  // Mac is 6 bytes, we can fit them in 8 bytes.
-      std::vector<std::string> split = absl::StrSplit(value.mac(), ":");
-      for (size_t i = 0; i < split.size(); i++) {
-        uint64_t decimal;  // Initially only 8 bits, but will be shifted.
-        std::stringstream converter;
-        converter << std::hex << split[i];
-        if (converter >> decimal) {
-          mac += decimal << ((split.size() - i - 1) * 8);
-        } else {
-          return absl::InvalidArgumentError(
-              absl::StrCat("Cannot process mac value \"", value.mac(), "\"!"));
-        }
-      }
-      return Z3Context().bv_val(std::to_string(mac).c_str(), 48);
-    }
-
-    case pdpi::IrValue::kIpv6: {
-      uint64_t ipv6 = 0;  // Ipv6 is 128 bits, do it in two 64 bits steps.
-      std::vector<std::string> split = absl::StrSplit(value.ipv6(), ":");
-
-      // Transform the most significant 64 bits.
-      for (size_t i = 0; i < split.size() / 2; i++) {
-        uint64_t decimal;  // Initially only 16 bits, but will be shifted.
-        std::stringstream converter;
-        converter << std::hex << split[i];
-        if (converter >> decimal) {
-          ipv6 += decimal << ((split.size() / 2 - i - 1) * 16);
-        } else {
-          return absl::InvalidArgumentError(absl::StrCat(
-              "Cannot process ipv6 value \"", value.ipv6(), "\"!"));
-        }
-      }
-      z3::expr hi = Z3Context().bv_val(std::to_string(ipv6).c_str(), 128);
-
-      // Transform the least significant 64 bits.
-      ipv6 = 0;
-      for (size_t i = split.size() / 2; i < split.size(); i++) {
-        uint64_t decimal;
-        std::stringstream converter;
-        converter << std::hex << split[i];
-        if (converter >> decimal) {
-          ipv6 += decimal << ((split.size() - i - 1) * 16);
-        } else {
-          return absl::InvalidArgumentError(absl::StrCat(
-              "Cannot process ipv6 value \"", value.ipv6(), "\"!"));
-        }
-      }
-      z3::expr lo = Z3Context().bv_val(std::to_string(ipv6).c_str(), 128);
-
-      // Add them together.
-      z3::expr shift = Z3Context().bv_val("18446744073709551616", 128);  // 2^64
-      ASSIGN_OR_RETURN(hi, operators::Times(hi, shift));  // shift << 64.
-      return operators::Plus(hi, lo);
-    }
-
-    default:
-      return absl::UnimplementedError(
-          absl::StrCat("Found unsupported value type ", value.DebugString()));
-  }
-}
-
-gutil::StatusOr<pdpi::IrValue> StringToIrValue(std::string value) {
-  // Format according to type.
-  if (absl::StartsWith(value, "0x")) {
-    return pdpi::FormattedStringToIrValue(value, pdpi::Format::HEX_STRING);
-  } else {
-    // Some unsupported format!
-    return absl::InvalidArgumentError(
-        absl::StrCat("Literal value \"", value, "\" has unknown format!"));
-  }
 }
 
 }  // namespace util

--- a/p4_symbolic/symbolic/util.cc
+++ b/p4_symbolic/symbolic/util.cc
@@ -83,7 +83,7 @@ SymbolicTableMatch DefaultTableMatch() {
 
 gutil::StatusOr<ConcreteContext> ExtractFromModel(
     SymbolicContext context, z3::model model,
-    const values::ValueFormatter &value_formatter) {
+    const values::P4RuntimeTranslator &translator) {
   // Extract ports.
   std::string ingress_port = model.eval(context.ingress_port, true).to_string();
   std::string egress_port = model.eval(context.egress_port, true).to_string();
@@ -98,14 +98,14 @@ gutil::StatusOr<ConcreteContext> ExtractFromModel(
   ConcretePerPacketState ingress_headers;
   for (const auto &[name, expr] : context.ingress_headers) {
     ASSIGN_OR_RETURN(ingress_headers[name],
-                     value_formatter.TranslateValueToString(
-                         name, model.eval(expr, true).to_string()));
+                     values::TranslateValueToP4RT(
+                         name, model.eval(expr, true).to_string(), translator));
   }
   ConcretePerPacketState egress_headers;
   for (const auto &[name, expr] : context.egress_headers) {
     ASSIGN_OR_RETURN(egress_headers[name],
-                     value_formatter.TranslateValueToString(
-                         name, model.eval(expr, true).to_string()));
+                     values::TranslateValueToP4RT(
+                         name, model.eval(expr, true).to_string(), translator));
   }
 
   // Extract the trace (matches on every table).

--- a/p4_symbolic/symbolic/util.cc
+++ b/p4_symbolic/symbolic/util.cc
@@ -89,12 +89,10 @@ gutil::StatusOr<ConcreteContext> ExtractFromModel(
   std::string egress_port = model.eval(context.egress_port, true).to_string();
 
   // Extract an input packet and its predicted output.
-  ASSIGN_OR_RETURN(ConcretePacket ingress_packet,
-                   packet::ExtractConcretePacket(context.ingress_packet, model,
-                                                 value_formatter));
-  ASSIGN_OR_RETURN(ConcretePacket egress_packet,
-                   packet::ExtractConcretePacket(context.egress_packet, model,
-                                                 value_formatter));
+  ConcretePacket ingress_packet =
+      packet::ExtractConcretePacket(context.ingress_packet, model);
+  ConcretePacket egress_packet =
+      packet::ExtractConcretePacket(context.egress_packet, model);
 
   // Extract the ingress and egress headers.
   ConcretePerPacketState ingress_headers;

--- a/p4_symbolic/symbolic/util.h
+++ b/p4_symbolic/symbolic/util.h
@@ -46,7 +46,7 @@ SymbolicTableMatch DefaultTableMatch();
 // expression in the model.
 gutil::StatusOr<ConcreteContext> ExtractFromModel(
     SymbolicContext context, z3::model model,
-    const values::ValueFormatter &value_formatter);
+    const values::P4RuntimeTranslator &translator);
 
 // Merges two symbolic traces into a single trace. A field in the new trace
 // has the value of the changed trace if the condition is true, and the value

--- a/p4_symbolic/symbolic/util.h
+++ b/p4_symbolic/symbolic/util.h
@@ -25,6 +25,7 @@
 #include "p4_pdpi/ir.pb.h"
 #include "p4_symbolic/ir/ir.pb.h"
 #include "p4_symbolic/symbolic/symbolic.h"
+#include "p4_symbolic/symbolic/values.h"
 #include "z3++.h"
 
 namespace p4_symbolic {
@@ -43,8 +44,9 @@ SymbolicTableMatch DefaultTableMatch();
 
 // Extract a concrete context by evaluating every component's corresponding
 // expression in the model.
-gutil::StatusOr<ConcreteContext> ExtractFromModel(SymbolicContext context,
-                                                  z3::model model);
+gutil::StatusOr<ConcreteContext> ExtractFromModel(
+    SymbolicContext context, z3::model model,
+    const values::ValueFormatter &value_formatter);
 
 // Merges two symbolic traces into a single trace. A field in the new trace
 // has the value of the changed trace if the condition is true, and the value

--- a/p4_symbolic/symbolic/util.h
+++ b/p4_symbolic/symbolic/util.h
@@ -56,50 +56,6 @@ gutil::StatusOr<SymbolicTrace> MergeTracesOnCondition(
     const z3::expr &condition, const SymbolicTrace &true_trace,
     const SymbolicTrace &false_trace);
 
-// Transforms a hex string literal from bmv2 json to a pdpi::IrValue
-gutil::StatusOr<pdpi::IrValue> ParseIrValue(std::string value);
-
-// Transforms a value read from bmv2 (e.g. hardcoded in the program)
-// to a z3::expr.
-// Essentially, this is just a formatting function that can format ipv4, ipv6
-// hexstrings, and macs as bitvectors in z3's format.
-// This function does not perform any string translation, and instead assumes
-// the values are already in the actual domain of values in the p4 program,
-// because p4 and bmv2 both do not support string translation, it is only used
-// as a logical translation at the boundry between P4RT and bmv2.
-gutil::StatusOr<z3::expr> Bmv2ValueZ3Expr(const pdpi::IrValue &value);
-
-// Transforms a value read from a table entry to a z3::expr.
-// On top of formatting ipv4, ipv6, hexstrings, and macs as bitvectors,
-// this function also translates string values to unique and arbitrary
-// bitvectors.
-// The mapping of strings to bitvectors is stored and used to map the same
-// string to the same consistent bitvector, and to also do a reverse-translation
-// when extracting values for headers and fields from the z3 model.
-gutil::StatusOr<z3::expr> P4RTValueZ3Expr(const std::string field_name,
-                                          const pdpi::IrValue &value);
-
-// Exposes a static mapping from string values to bitvector values.
-// We do not need to include field names here because we assume the string
-// values are unique.
-std::unordered_map<std::string, uint64_t> &StringToBitVectorTranslationMap();
-
-// Exposes a static mapping from field names and bitvector values to
-// string values.
-std::unordered_map<std::string, std::unordered_map<uint64_t, std::string>>
-    &BitVectorToStringTranslationMap();
-
-// Exposes a static mapping from field name to count of strings translated
-// for that field.
-std::unordered_map<std::string, uint64_t> &FieldNameToStringCountMap();
-
-// Reverse translation of internal values from the p4/bmv2 value domain
-// to the string domain of P4RT.
-// If this is called on values belonging to fields without a
-// @p4runtime_translation annotation, it is a no-op.
-gutil::StatusOr<std::string> TranslateValueToString(
-    const std::string field_name, const std::string &value);
-
 }  // namespace util
 }  // namespace symbolic
 }  // namespace p4_symbolic

--- a/p4_symbolic/symbolic/values.cc
+++ b/p4_symbolic/symbolic/values.cc
@@ -1,0 +1,268 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is responsible for parsing values from the bmv2 json and table
+// entries.
+// It is also responsible for translating any string values to corresponding
+// bitvectors and back, for fields that have the @p4runtime_translation
+// annotation.
+
+#include "p4_symbolic/symbolic/values.h"
+
+#include <cstdint>
+#include <locale>
+#include <sstream>
+#include <vector>
+
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/strip.h"
+#include "p4_pdpi/utils/ir.h"
+#include "p4_symbolic/symbolic/operators.h"
+#include "p4_symbolic/symbolic/symbolic.h"
+
+namespace p4_symbolic {
+namespace symbolic {
+namespace values {
+
+gutil::StatusOr<pdpi::IrValue> ParseIrValue(std::string value) {
+  // Format according to type.
+  if (absl::StartsWith(value, "0x")) {
+    return pdpi::FormattedStringToIrValue(value, pdpi::Format::HEX_STRING);
+  } else {
+    // Some unsupported format!
+    return absl::InvalidArgumentError(
+        absl::StrCat("Literal value \"", value, "\" has unknown format!"));
+  }
+}
+
+gutil::StatusOr<z3::expr> Bmv2ValueZ3Expr(const pdpi::IrValue &value) {
+  switch (value.format_case()) {
+    case pdpi::IrValue::kHexStr: {
+      const std::string &hexstr = value.hex_str();
+
+      uint64_t decimal;
+      std::stringstream converter;
+      converter << std::hex << hexstr;
+      if (converter >> decimal) {
+        unsigned int bitsize = 0;
+        uint64_t pow = 1;
+        while (bitsize <= 64 && pow <= decimal) {
+          pow = pow * 2;
+          bitsize++;
+        }
+        bitsize = (bitsize > 1 ? bitsize : 1);  // At least 1 bit.
+        return Z3Context().bv_val(std::to_string(decimal).c_str(), bitsize);
+      }
+
+      return absl::InvalidArgumentError(absl::StrCat(
+          "Cannot process hex string \"", hexstr, "\", the value is too big!"));
+    }
+
+    case pdpi::IrValue::kIpv4: {
+      uint32_t ip = 0;
+      std::vector<std::string> ipv4 = absl::StrSplit(value.ipv4(), ".");
+      for (size_t i = 0; i < ipv4.size(); i++) {
+        uint32_t shifted_component = static_cast<uint32_t>(std::stoull(ipv4[i]))
+                                     << ((ipv4.size() - i - 1) * 8);
+        ip += shifted_component;
+      }
+      return Z3Context().bv_val(std::to_string(ip).c_str(), 32);
+    }
+
+    case pdpi::IrValue::kMac: {
+      uint64_t mac = 0;  // Mac is 6 bytes, we can fit them in 8 bytes.
+      std::vector<std::string> split = absl::StrSplit(value.mac(), ":");
+      for (size_t i = 0; i < split.size(); i++) {
+        uint64_t decimal;  // Initially only 8 bits, but will be shifted.
+        std::stringstream converter;
+        converter << std::hex << split[i];
+        if (converter >> decimal) {
+          mac += decimal << ((split.size() - i - 1) * 8);
+        } else {
+          return absl::InvalidArgumentError(
+              absl::StrCat("Cannot process mac value \"", value.mac(), "\"!"));
+        }
+      }
+      return Z3Context().bv_val(std::to_string(mac).c_str(), 48);
+    }
+
+    case pdpi::IrValue::kIpv6: {
+      uint64_t ipv6 = 0;  // Ipv6 is 128 bits, do it in two 64 bits steps.
+      std::vector<std::string> split = absl::StrSplit(value.ipv6(), ":");
+
+      // Transform the most significant 64 bits.
+      for (size_t i = 0; i < split.size() / 2; i++) {
+        uint64_t decimal;  // Initially only 16 bits, but will be shifted.
+        std::stringstream converter;
+        converter << std::hex << split[i];
+        if (converter >> decimal) {
+          ipv6 += decimal << ((split.size() / 2 - i - 1) * 16);
+        } else {
+          return absl::InvalidArgumentError(absl::StrCat(
+              "Cannot process ipv6 value \"", value.ipv6(), "\"!"));
+        }
+      }
+      z3::expr hi = Z3Context().bv_val(std::to_string(ipv6).c_str(), 128);
+
+      // Transform the least significant 64 bits.
+      ipv6 = 0;
+      for (size_t i = split.size() / 2; i < split.size(); i++) {
+        uint64_t decimal;
+        std::stringstream converter;
+        converter << std::hex << split[i];
+        if (converter >> decimal) {
+          ipv6 += decimal << ((split.size() - i - 1) * 16);
+        } else {
+          return absl::InvalidArgumentError(absl::StrCat(
+              "Cannot process ipv6 value \"", value.ipv6(), "\"!"));
+        }
+      }
+      z3::expr lo = Z3Context().bv_val(std::to_string(ipv6).c_str(), 128);
+
+      // Add them together.
+      z3::expr shift = Z3Context().bv_val("18446744073709551616", 128);  // 2^64
+      ASSIGN_OR_RETURN(hi, operators::Times(hi, shift));  // shift << 64.
+      return operators::Plus(hi, lo);
+    }
+
+    default:
+      return absl::UnimplementedError(
+          absl::StrCat("Found unsupported value type ", value.DebugString()));
+  }
+}
+
+gutil::StatusOr<z3::expr> P4RTValueZ3Expr(const std::string field_name,
+                                          const pdpi::IrValue &value) {
+  switch (value.format_case()) {
+    case pdpi::IrValue::kStr: {
+      // Must translate the string into a bitvector.
+      const std::string &string_value = value.str();
+      auto &string_to_bitvector = StringToBitVectorTranslationMap();
+      if (string_to_bitvector.count(string_value) == 1) {
+        // This string was encountered previously and was already translated.
+        z3::expr z3_value = string_to_bitvector.at(string_value);
+        // Insert the previously translated value into the reverse mapping,
+        // this is useful in case the same string value was previously
+        // translated for a different field, this way that value gets tied
+        // to this field as well.
+        // If the value was previously translated for the same field, this
+        // is a no-op.
+        auto &bitvector_to_string = BitVectorToStringTranslationMap();
+        if (bitvector_to_string.count(field_name) != 1) {
+          bitvector_to_string.insert({field_name, {}});
+        }
+        bitvector_to_string.at(field_name)
+            .insert({z3_value.to_string(), string_value});
+        return z3_value;
+      } else {
+        // First time encountering this value. Come up with some bitvector
+        // value for it unique relative to this field.
+        auto &count_map = FieldNameToStringCountMap();
+        if (count_map.count(field_name) != 1) {
+          count_map.insert({field_name, 0});
+        }
+        uint64_t int_value = count_map.at(field_name)++;
+
+        // Find the bitsize of int_value.
+        // The bitvector will be created with that initial bitsize, if the
+        // context of this value expected a larger bitsize, the value will be
+        // padded at the context.
+        // If the context expects a smaller bitsize, the context will return an
+        // error, since that means the number of unique strings used exceed the
+        // total size of the actual domain as defined in the p4 program.
+        unsigned int bitsize = 0;
+        uint64_t pow = 1;
+        while (bitsize <= 64 && pow <= int_value) {
+          pow = pow * 2;
+          bitsize++;
+        }
+        bitsize = (bitsize > 1 ? bitsize : 1);  // At least 1 bit.
+        z3::expr z3_value = Z3Context().bv_val(int_value, bitsize);
+
+        // Store this z3::expr and its corresponding string value in the mapping
+        // and reverse mapping for future lookups.
+        string_to_bitvector.insert({string_value, z3_value});
+        auto &bitvector_to_string = BitVectorToStringTranslationMap();
+        if (bitvector_to_string.count(field_name) != 1) {
+          bitvector_to_string.insert({field_name, {}});
+        }
+        bitvector_to_string.at(field_name)
+            .insert({z3_value.to_string(), string_value});
+      }
+    }
+    default: {
+      if (BitVectorToStringTranslationMap().count(field_name) == 1) {
+        return absl::InvalidArgumentError(absl::StrCat(
+            "A table entry provides a non-string value ", value.DebugString(),
+            "to a string translated field", field_name));
+      }
+      return Bmv2ValueZ3Expr(value);
+    }
+  }
+}
+
+// Exposes a static mapping from string values to bitvector values.
+// We do not need to include field names here because we assume the string
+// values are unique.
+std::unordered_map<std::string, z3::expr> &StringToBitVectorTranslationMap() {
+  static std::unordered_map<std::string, z3::expr> *string_to_bitvector_map =
+      new std::unordered_map<std::string, z3::expr>();
+  return *string_to_bitvector_map;
+}
+
+// Exposes a static mapping from field names and bitvector values to
+// string values.
+std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+    &BitVectorToStringTranslationMap() {
+  static std::unordered_map<std::string,
+                            std::unordered_map<std::string, std::string>>
+      *bitvector_to_string_map = new std::unordered_map<
+          std::string, std::unordered_map<std::string, std::string>>();
+  return *bitvector_to_string_map;
+}
+
+std::unordered_map<std::string, uint64_t> &FieldNameToStringCountMap() {
+  static std::unordered_map<std::string, uint64_t>
+      *field_name_to_string_count_map =
+          new std::unordered_map<std::string, uint64_t>();
+  return *field_name_to_string_count_map;
+}
+
+// Reverse translation of internal values from the p4/bmv2 value domain
+// to the string domain of P4RT.
+// If this is called on values belonging to fields without a
+// @p4runtime_translation annotation, it is a no-op.
+gutil::StatusOr<std::string> TranslateValueToString(
+    const std::string field_name, const std::string &value) {
+  auto &count_map = FieldNameToStringCountMap();
+  if (count_map.count(field_name) == 1) {
+    const auto &reverse_map = BitVectorToStringTranslationMap();
+    if (reverse_map.count(field_name) == 1) {
+      if (reverse_map.at(field_name).count(value) == 1) {
+        return reverse_map.at(field_name).at(value);
+      }
+    }
+    return absl::InvalidArgumentError(
+        absl::StrCat("Cannot translate value ", value,
+                     " to a string value for field ", field_name));
+  }
+  return value;
+}
+
+}  // namespace values
+}  // namespace symbolic
+}  // namespace p4_symbolic

--- a/p4_symbolic/symbolic/values.h
+++ b/p4_symbolic/symbolic/values.h
@@ -12,47 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Helpful utilities for managing symbolic and concrete headers and values.
+// This file is responsible for parsing values from the bmv2 json and table
+// entries.
+// It is also responsible for translating any string values to corresponding
+// bitvectors and back, for fields that have the @p4runtime_translation
+// annotation.
 
-#ifndef P4_SYMBOLIC_SYMBOLIC_UTIL_H_
-#define P4_SYMBOLIC_SYMBOLIC_UTIL_H_
+#ifndef P4_SYMBOLIC_SYMBOLIC_VALUES_H_
+#define P4_SYMBOLIC_SYMBOLIC_VALUES_H_
 
 #include <string>
 #include <unordered_map>
 
-#include "google/protobuf/map.h"
 #include "gutil/status.h"
 #include "p4_pdpi/ir.pb.h"
-#include "p4_symbolic/ir/ir.pb.h"
-#include "p4_symbolic/symbolic/symbolic.h"
 #include "z3++.h"
 
 namespace p4_symbolic {
 namespace symbolic {
-namespace util {
-
-// Free (unconstrained) symbolic headers consisting of free symbolic variables
-// for every field in every header instance defined in the P4 program.
-gutil::StatusOr<std::unordered_map<std::string, z3::expr>> FreeSymbolicHeaders(
-    const google::protobuf::Map<std::string, ir::HeaderType> &headers);
-
-// Returns an symbolic table match containing default values.
-// The table match expression is false, the index is -1, and the value is
-// undefined.
-SymbolicTableMatch DefaultTableMatch();
-
-// Extract a concrete context by evaluating every component's corresponding
-// expression in the model.
-gutil::StatusOr<ConcreteContext> ExtractFromModel(SymbolicContext context,
-                                                  z3::model model);
-
-// Merges two symbolic traces into a single trace. A field in the new trace
-// has the value of the changed trace if the condition is true, and the value
-// of the original one otherwise.
-// Assertion: both traces must contain matches for the same set of table names.
-gutil::StatusOr<SymbolicTrace> MergeTracesOnCondition(
-    const z3::expr &condition, const SymbolicTrace &true_trace,
-    const SymbolicTrace &false_trace);
+namespace values {
 
 // Transforms a hex string literal from bmv2 json to a pdpi::IrValue
 gutil::StatusOr<pdpi::IrValue> ParseIrValue(std::string value);
@@ -80,11 +58,11 @@ gutil::StatusOr<z3::expr> P4RTValueZ3Expr(const std::string field_name,
 // Exposes a static mapping from string values to bitvector values.
 // We do not need to include field names here because we assume the string
 // values are unique.
-std::unordered_map<std::string, uint64_t> &StringToBitVectorTranslationMap();
+std::unordered_map<std::string, z3::expr> &StringToBitVectorTranslationMap();
 
 // Exposes a static mapping from field names and bitvector values to
 // string values.
-std::unordered_map<std::string, std::unordered_map<uint64_t, std::string>>
+std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
     &BitVectorToStringTranslationMap();
 
 // Exposes a static mapping from field name to count of strings translated
@@ -98,8 +76,8 @@ std::unordered_map<std::string, uint64_t> &FieldNameToStringCountMap();
 gutil::StatusOr<std::string> TranslateValueToString(
     const std::string field_name, const std::string &value);
 
-}  // namespace util
+}  // namespace values
 }  // namespace symbolic
 }  // namespace p4_symbolic
 
-#endif  // P4_SYMBOLIC_SYMBOLIC_UTIL_H_
+#endif  // P4_SYMBOLIC_SYMBOLIC_VALUES_H_

--- a/p4_symbolic/symbolic/values.h
+++ b/p4_symbolic/symbolic/values.h
@@ -32,6 +32,49 @@ namespace p4_symbolic {
 namespace symbolic {
 namespace values {
 
+// This class is responsible for formatting various values into consistent
+// format acceptable by z3.
+// The class transforms pdpi::IrValue instances to z3::expr, it also handles
+// translation (and reverse translation) of P4RT string values that are meant
+// to be translated to bitvectors, because of @p4runtime_translation
+// annotations.
+class IdAllocator {
+ public:
+  // Allocates an arbitrary bitvector to this string identifier.
+  // The bitvector is guaranteed to be consistent (the same bitvector is
+  // allocated to equal strings), and unique per instance of this class.
+  z3::expr AllocateBitVector(const std::string &string_value);
+
+  // Reverse translation of an allocated bit vector to the string value for
+  // which it was allocated.
+  gutil::StatusOr<std::string> BitVectorToString(
+      const std::string &value) const;
+
+ private:
+  // A mapping from string values to bitvector values.
+  std::unordered_map<std::string, z3::expr> string_to_bitvector_map_;
+
+  // A mapping from bitvector values to string values.
+  std::unordered_map<std::string, std::string> bitvector_to_string_map_;
+
+  // Counter used to come up with new values per new allocation.
+  uint64_t counter_ = 0;
+};
+
+// This struct stores all the state that is required to translate string values
+// to internal bitvectors per custom p4 type (e.g. vrf_t), and reverse translate
+// bitvector values of fields of such a custom type to a string value.
+struct P4RuntimeTranslator {
+  // Maps type name to an allocator responsible for translating values for it.
+  std::unordered_map<std::string, IdAllocator> p4runtime_translation_allocators;
+  // Maps field name to a type name, only for fields we were able to detect had
+  // a custom p4 type with a @p4runtime_translation annotation attached to it.
+  // This information is not available in the bmv2 file, since it strips away
+  // type aliases and  annotations, so we must build it ourselves with a best
+  // effort approach.
+  std::unordered_map<std::string, std::string> fields_p4runtime_type;
+};
+
 // Transforms a hex string literal from bmv2 json to a pdpi::IrValue
 gutil::StatusOr<pdpi::IrValue> ParseIrValue(std::string value);
 
@@ -45,47 +88,28 @@ gutil::StatusOr<pdpi::IrValue> ParseIrValue(std::string value);
 // as a logical translation at the boundry between P4RT and bmv2.
 gutil::StatusOr<z3::expr> FormatBmv2Value(const pdpi::IrValue &value);
 
-// This class is responsible for formatting various values into consistent
-// format acceptable by z3.
-// The class transforms pdpi::IrValue instances to z3::expr, it also handles
-// translation (and reverse translation) of P4RT string values that are meant
-// to be translated to bitvectors, because of @p4runtime_translation
-// annotations.
-class ValueFormatter {
- public:
-  // Transforms a value read from a table entry to a z3::expr.
-  // On top of formatting ipv4, ipv6, hexstrings, and macs as bitvectors,
-  // this function also translates string values to unique and arbitrary
-  // bitvectors.
-  // The mapping of strings to bitvectors is stored and used to map the same
-  // string to the same consistent bitvector, and to also do a
-  // reverse-translation when extracting values for headers and fields from the
-  // z3 model.
-  gutil::StatusOr<z3::expr> FormatP4RTValue(const std::string field_name,
-                                            const pdpi::IrValue &value);
+// Transforms a value read from a table entry to a z3::expr.
+// On top of formatting ipv4, ipv6, hexstrings, and macs as bitvectors,
+// this function also translates string values to unique bitvectors.
+// The mapping of strings to bitvectors is stored in the translator state,
+//  and used to map the same string to the same consistent bitvector, and to
+// do a reverse-translation when extracting values for headers and fields from
+// the z3 model.
+gutil::StatusOr<z3::expr> FormatP4RTValue(const std::string &field_name,
+                                          const std::string &type_name,
+                                          const pdpi::IrValue &value,
+                                          P4RuntimeTranslator *translator);
 
-  // Reverse translation of internal values from the p4/bmv2 value domain
-  // to the string domain of P4RT.
-  // If this is called on values belonging to fields without a
-  // @p4runtime_translation annotation, it is a no-op.
-  gutil::StatusOr<std::string> TranslateValueToString(
-      const std::string field_name, const std::string &value) const;
-
- private:
-  // A mapping from string values to bitvector values.
-  // We do not need to include field names here because we assume the string
-  // values are unique.
-  std::unordered_map<std::string, z3::expr> string_to_bitvector_map_;
-
-  // A mapping from field names and bitvector values to string values.
-  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
-      field_name_to_string_map_;
-
-  // A mapping from field name to count of strings translated for that field.
-  // This is used to come up with new unique (per field) bitvector values
-  // for newly encountered strings.
-  std::unordered_map<std::string, uint64_t> field_name_to_string_count_map_;
-};
+// Reverse translation: operates opposite to FormatP4RTValue().
+// If the given field was not detected to be translatable (perhaps it is indeed
+// not translatable), the function returns the value unchanged.
+// If the given field was detected to be translatable (e.g. some values for it
+// were previously translated by a call to FormatP4RTValue), then the value
+// is looked up using the reverse mapping inside the given translator, if that
+// look fails, an absl error is returned.
+gutil::StatusOr<std::string> TranslateValueToP4RT(
+    const std::string &field_name, const std::string &value,
+    const P4RuntimeTranslator &translator);
 
 }  // namespace values
 }  // namespace symbolic

--- a/p4_symbolic/symbolic/values.h
+++ b/p4_symbolic/symbolic/values.h
@@ -43,38 +43,49 @@ gutil::StatusOr<pdpi::IrValue> ParseIrValue(std::string value);
 // the values are already in the actual domain of values in the p4 program,
 // because p4 and bmv2 both do not support string translation, it is only used
 // as a logical translation at the boundry between P4RT and bmv2.
-gutil::StatusOr<z3::expr> Bmv2ValueZ3Expr(const pdpi::IrValue &value);
+gutil::StatusOr<z3::expr> FormatBmv2Value(const pdpi::IrValue &value);
 
-// Transforms a value read from a table entry to a z3::expr.
-// On top of formatting ipv4, ipv6, hexstrings, and macs as bitvectors,
-// this function also translates string values to unique and arbitrary
-// bitvectors.
-// The mapping of strings to bitvectors is stored and used to map the same
-// string to the same consistent bitvector, and to also do a reverse-translation
-// when extracting values for headers and fields from the z3 model.
-gutil::StatusOr<z3::expr> P4RTValueZ3Expr(const std::string field_name,
-                                          const pdpi::IrValue &value);
+// This class is responsible for formatting various values into consistent
+// format acceptable by z3.
+// The class transforms pdpi::IrValue instances to z3::expr, it also handles
+// translation (and reverse translation) of P4RT string values that are meant
+// to be translated to bitvectors, because of @p4runtime_translation
+// annotations.
+class ValueFormatter {
+ public:
+  // Transforms a value read from a table entry to a z3::expr.
+  // On top of formatting ipv4, ipv6, hexstrings, and macs as bitvectors,
+  // this function also translates string values to unique and arbitrary
+  // bitvectors.
+  // The mapping of strings to bitvectors is stored and used to map the same
+  // string to the same consistent bitvector, and to also do a
+  // reverse-translation when extracting values for headers and fields from the
+  // z3 model.
+  gutil::StatusOr<z3::expr> FormatP4RTValue(const std::string field_name,
+                                            const pdpi::IrValue &value);
 
-// Exposes a static mapping from string values to bitvector values.
-// We do not need to include field names here because we assume the string
-// values are unique.
-std::unordered_map<std::string, z3::expr> &StringToBitVectorTranslationMap();
+  // Reverse translation of internal values from the p4/bmv2 value domain
+  // to the string domain of P4RT.
+  // If this is called on values belonging to fields without a
+  // @p4runtime_translation annotation, it is a no-op.
+  gutil::StatusOr<std::string> TranslateValueToString(
+      const std::string field_name, const std::string &value) const;
 
-// Exposes a static mapping from field names and bitvector values to
-// string values.
-std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
-    &BitVectorToStringTranslationMap();
+ private:
+  // A mapping from string values to bitvector values.
+  // We do not need to include field names here because we assume the string
+  // values are unique.
+  std::unordered_map<std::string, z3::expr> string_to_bitvector_map_;
 
-// Exposes a static mapping from field name to count of strings translated
-// for that field.
-std::unordered_map<std::string, uint64_t> &FieldNameToStringCountMap();
+  // A mapping from field names and bitvector values to string values.
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+      field_name_to_string_map_;
 
-// Reverse translation of internal values from the p4/bmv2 value domain
-// to the string domain of P4RT.
-// If this is called on values belonging to fields without a
-// @p4runtime_translation annotation, it is a no-op.
-gutil::StatusOr<std::string> TranslateValueToString(
-    const std::string field_name, const std::string &value);
+  // A mapping from field name to count of strings translated for that field.
+  // This is used to come up with new unique (per field) bitvector values
+  // for newly encountered strings.
+  std::unordered_map<std::string, uint64_t> field_name_to_string_count_map_;
+};
 
 }  // namespace values
 }  // namespace symbolic


### PR DESCRIPTION
* String values are read from the p4rt table entries
* They are translated to bit-vectors of appropriate size prior to using them in constraints or the solver.
* Mapping between strings and bit-vectors are maintained for consistent translation and reverse translation.
* Outputs acquired from the constraints are reverse translated, and shown as strings in the output of this tool.
* Stored bit-vectors are normalized to avoid issues reverse translating them in cases of padding or formatting transformations.
* All added code is either not executed or is executed without effects (no-op) for fields and values that do not need translation.